### PR TITLE
Første steg i migreringen av trygdetid-domenet inn i etterlatte-behahdling

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidBeregningService.kt
@@ -1,0 +1,143 @@
+package no.nav.etterlatte.trygdetid
+
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.KonstantGrunnlag
+import no.nav.etterlatte.libs.regler.RegelPeriode
+import no.nav.etterlatte.libs.regler.RegelkjoeringResultat
+import no.nav.etterlatte.libs.regler.eksekver
+import no.nav.etterlatte.trygdetid.regler.TrygdetidGrunnlagMedAvdoedGrunnlag
+import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeGrunnlag
+import no.nav.etterlatte.trygdetid.regler.TrygdetidPeriodeMedPoengaar
+import no.nav.etterlatte.trygdetid.regler.beregnDetaljertBeregnetTrygdetidMedYrkesskade
+import no.nav.etterlatte.trygdetid.regler.beregnTrygdetidForPeriode
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+object TrygdetidBeregningService {
+    private val logger = LoggerFactory.getLogger(TrygdetidBeregningService::class.java)
+
+    fun beregnTrygdetid(
+        trygdetidGrunnlag: List<TrygdetidGrunnlag>,
+        foedselsDato: LocalDate,
+        doedsDato: LocalDate,
+        norskPoengaar: Int?,
+        yrkesskade: Boolean,
+        nordiskKonvensjon: Boolean,
+    ): DetaljertBeregnetTrygdetid? {
+        logger.info("Beregner antall år trygdetid")
+
+        val beregnetTrygdetidListe = trygdetidGrunnlag.mapNotNull { it.beregnetTrygdetid }
+
+        // Hvis vi ikke har noe grunnlag eller overstyring av poengår eller yrkesskade har vi ikke
+        // noen trygdetid å beregne
+        if (beregnetTrygdetidListe.isEmpty() && norskPoengaar == null && !yrkesskade) {
+            logger.info("Har ingen perioder med beregnet trygdetidsgrunnlag og ingen overstyrt poengår.")
+            return null
+        }
+
+        val grunnlag =
+            TrygdetidGrunnlagMedAvdoedGrunnlag(
+                trygdetidGrunnlagListe =
+                    FaktumNode(
+                        verdi = trygdetidGrunnlag,
+                        kilde = "System",
+                        beskrivelse = "Trygdetidsperioder",
+                    ),
+                foedselsDato =
+                    FaktumNode(
+                        verdi = foedselsDato,
+                        kilde = "System",
+                        beskrivelse = "Fødselsdato",
+                    ),
+                doedsDato =
+                    FaktumNode(
+                        verdi = doedsDato,
+                        kilde = "System",
+                        beskrivelse = "Dødsdato",
+                    ),
+                norskPoengaar =
+                    FaktumNode(
+                        verdi = norskPoengaar,
+                        kilde = "System",
+                        beskrivelse = "Norske poengår",
+                    ),
+                yrkesskade =
+                    FaktumNode(
+                        verdi = yrkesskade,
+                        kilde = "System",
+                        beskrivelse = "Yrkesskade",
+                    ),
+                nordiskKonvensjon =
+                    FaktumNode(
+                        verdi = nordiskKonvensjon,
+                        kilde = "System",
+                        beskrivelse = "Nordisk konvensjon",
+                    ),
+            )
+
+        val resultat =
+            beregnDetaljertBeregnetTrygdetidMedYrkesskade.eksekver(
+                KonstantGrunnlag(grunnlag),
+                RegelPeriode(LocalDate.now()),
+            )
+        return when (resultat) {
+            is RegelkjoeringResultat.Suksess -> {
+                val periodisertResultat = resultat.periodiserteResultater.first().resultat
+                val detaljertTrygdetidVerdi = periodisertResultat.verdi
+
+                logger.info("Beregning fullførte med resultat: $detaljertTrygdetidVerdi")
+                DetaljertBeregnetTrygdetid(
+                    resultat = detaljertTrygdetidVerdi,
+                    tidspunkt = Tidspunkt(periodisertResultat.opprettet),
+                    regelResultat = periodisertResultat.toJsonNode(),
+                )
+            }
+
+            is RegelkjoeringResultat.UgyldigPeriode -> {
+                throw Exception("En feil oppstod under regelkjøring")
+            }
+        }
+    }
+
+    fun beregnTrygdetidGrunnlag(trygdetidGrunnlag: TrygdetidGrunnlag): BeregnetTrygdetidGrunnlag? {
+        logger.info("Beregner trygdetid for trygdetidsgrunnlag ${trygdetidGrunnlag.id}")
+
+        val grunnlag =
+            TrygdetidPeriodeGrunnlag(
+                periode =
+                    FaktumNode(
+                        verdi =
+                            TrygdetidPeriodeMedPoengaar(
+                                fra = trygdetidGrunnlag.periode.fra,
+                                til = trygdetidGrunnlag.periode.til,
+                                poengInnAar = trygdetidGrunnlag.poengInnAar,
+                                poengUtAar = trygdetidGrunnlag.poengUtAar,
+                            ),
+                        kilde = trygdetidGrunnlag.kilde,
+                        beskrivelse = "Periode (med poeng aar) for trygdetidsperiode",
+                    ),
+            )
+
+        val resultat = beregnTrygdetidForPeriode.eksekver(KonstantGrunnlag(grunnlag), RegelPeriode(LocalDate.now()))
+        return when (resultat) {
+            is RegelkjoeringResultat.Suksess -> {
+                val periodisertResultat = resultat.periodiserteResultater.first().resultat
+                val periodeTrygdetid = periodisertResultat.verdi
+
+                logger.info("Beregning fullførte med resultat: $periodeTrygdetid")
+
+                BeregnetTrygdetidGrunnlag(
+                    verdi = periodeTrygdetid,
+                    tidspunkt = Tidspunkt(periodisertResultat.opprettet),
+                    regelResultat = periodisertResultat.toJsonNode(),
+                )
+            }
+
+            is RegelkjoeringResultat.UgyldigPeriode -> {
+                throw Exception("En feil oppstod under regelkjøring")
+            }
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidMapper.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidMapper.kt
@@ -1,0 +1,81 @@
+package no.nav.etterlatte.trygdetid
+
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.trygdetid.BeregnetTrygdetidGrunnlagDto
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidDto
+import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
+import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagDto
+import no.nav.etterlatte.libs.common.trygdetid.TrygdetidGrunnlagKildeDto
+
+fun Trygdetid.toDto(): TrygdetidDto =
+    TrygdetidDto(
+        id = id,
+        behandlingId = behandlingId,
+        beregnetTrygdetid = beregnetTrygdetid?.toDto(),
+        trygdetidGrunnlag = trygdetidGrunnlag.map { it.toDto() },
+        opplysninger = this.opplysninger.toDto(),
+        overstyrtNorskPoengaar = this.overstyrtNorskPoengaar,
+        ident = this.ident,
+        opplysningerDifferanse = krevIkkeNull(opplysningerDifferanse) { "Differanseopplysninger mangler" },
+        begrunnelse = this.begrunnelse,
+    )
+
+private fun DetaljertBeregnetTrygdetid.toDto(): DetaljertBeregnetTrygdetidDto =
+    DetaljertBeregnetTrygdetidDto(
+        resultat = resultat,
+        tidspunkt = tidspunkt,
+    )
+
+private fun TrygdetidGrunnlag.toDto(): TrygdetidGrunnlagDto =
+    TrygdetidGrunnlagDto(
+        id = id,
+        type = type.name,
+        bosted = bosted,
+        periodeFra = periode.fra,
+        periodeTil = periode.til,
+        beregnet =
+            beregnetTrygdetid?.let {
+                BeregnetTrygdetidGrunnlagDto(it.verdi.days, it.verdi.months, it.verdi.years)
+            },
+        kilde =
+            when (kilde) {
+                is Grunnlagsopplysning.Saksbehandler -> {
+                    TrygdetidGrunnlagKildeDto(
+                        tidspunkt = kilde.tidspunkt.toString(),
+                        ident = kilde.ident,
+                    )
+                }
+
+                is Grunnlagsopplysning.Pesys -> {
+                    TrygdetidGrunnlagKildeDto(
+                        tidspunkt = kilde.tidspunkt.toString(),
+                        ident = kilde.type,
+                    )
+                }
+
+                is Grunnlagsopplysning.Ufoeretrygd -> {
+                    TrygdetidGrunnlagKildeDto(
+                        tidspunkt = kilde.tidspunkt.toString(),
+                        ident = kilde.type,
+                    )
+                }
+
+                is Grunnlagsopplysning.Alderspensjon -> {
+                    TrygdetidGrunnlagKildeDto(
+                        tidspunkt = kilde.tidspunkt.toString(),
+                        ident = kilde.type,
+                    )
+                }
+
+                else -> {
+                    throw UnsupportedOperationException(
+                        "Kilde for trygdetid maa vaere saksbehandler, Ufoeretrygd, Alderspensjon eller pesys, var $kilde",
+                    )
+                }
+            },
+        begrunnelse = begrunnelse,
+        poengInnAar = poengInnAar,
+        poengUtAar = poengUtAar,
+        prorata = prorata,
+    )

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -1,0 +1,1329 @@
+package no.nav.etterlatte.trygdetid
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.module.kotlin.readValue
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.funksjonsbrytere.FeatureToggleService
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.ATTESTERT
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.AVKORTET
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.BEREGNET
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.FATTET_VEDTAK
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.IVERKSATT
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.SAMORDNET
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.TIL_SAMORDNING
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.JaNei
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.feilhaandtering.krev
+import no.nav.etterlatte.libs.common.feilhaandtering.krevIkkeNull
+import no.nav.etterlatte.libs.common.feilhaandtering.sjekkIkkeNull
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsdata
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
+import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsdato
+import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsnummer
+import no.nav.etterlatte.libs.common.logging.sikkerlogger
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.GrunnlagOpplysningerDto
+import no.nav.etterlatte.libs.common.trygdetid.OpplysningerDifferanse
+import no.nav.etterlatte.libs.common.trygdetid.TrygdetidDto
+import no.nav.etterlatte.libs.common.trygdetid.UKJENT_AVDOED
+import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.trygdetid.avtale.AvtaleService
+import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
+import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
+import no.nav.etterlatte.trygdetid.klienter.PesysKlient
+import no.nav.etterlatte.trygdetid.klienter.Trygdetidsgrunnlag
+import no.nav.etterlatte.trygdetid.klienter.TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon
+import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingKlient
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+import java.util.UUID
+
+interface TrygdetidService {
+    suspend fun hentTrygdetiderIBehandling(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid>
+
+    suspend fun hentTrygdetidIBehandlingMedId(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid?
+
+    suspend fun opprettTrygdetiderForBehandling(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+        overskriv: Boolean = false,
+    ): List<Trygdetid>
+
+    suspend fun harTrygdetidsgrunnlagIPesysForApOgUfoere(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean
+
+    suspend fun leggInnTrygdetidsgrunnlagFraPesys(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid>
+
+    suspend fun lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandlingMedSjekk(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        trygdetidGrunnlag: TrygdetidGrunnlag,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid
+
+    suspend fun slettTrygdetidGrunnlagForTrygdetid(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        trygdetidGrunnlagId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid
+
+    suspend fun slettPesysTrygdetidGrunnlagForTrygdetid(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid
+
+    suspend fun overstyrNorskPoengaaarForTrygdetid(
+        trygdetidId: UUID,
+        behandlingId: UUID,
+        overstyrtNorskPoengaar: Int?,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid
+
+    suspend fun setYrkesskade(
+        trygdetidId: UUID,
+        behandlingId: UUID,
+        yrkesskade: Boolean,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid
+
+    suspend fun oppdaterTrygdetidMedBegrunnelse(
+        trygdetidId: UUID,
+        behandlingId: UUID,
+        begrunnelse: String?,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid
+
+    suspend fun kopierSisteTrygdetidberegninger(
+        behandlingId: UUID,
+        forrigeBehandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid>
+
+    suspend fun kopierOgOverskrivTrygdetid(
+        behandlingId: UUID,
+        kildeBehandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<TrygdetidDto>
+
+    fun overstyrBeregnetTrygdetidForAvdoed(
+        behandlingId: UUID,
+        ident: String,
+        beregnetTrygdetid: DetaljertBeregnetTrygdetidResultat,
+    ): Trygdetid
+
+    suspend fun oppdaterOpplysningsgrunnlagForTrygdetider(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid>
+
+    suspend fun sjekkGyldighetOgOppdaterBehandlingStatus(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean
+
+    suspend fun opprettOverstyrtBeregnetTrygdetid(
+        behandlingId: UUID,
+        overskriv: Boolean,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid
+
+    suspend fun finnBehandlingMedTrygdetidForSammeAvdoede(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): UUID?
+}
+
+data class TrygdetidPeriodePesys(
+    val isoCode: String, // ISO 3166-1 alpha-3 code:
+    val fra: LocalDate,
+    val til: LocalDate,
+    val poengInnAar: Boolean?,
+    val poengUtAar: Boolean?,
+    val prorata: Boolean?,
+    val kilde: Grunnlagsopplysning.PesysYtelseKilde, // GrunnlagKildeCode i Pesys
+)
+
+private fun Trygdetidsgrunnlag.tilTrygdetidsPeriode(kilde: Grunnlagsopplysning.PesysYtelseKilde): TrygdetidPeriodePesys =
+    TrygdetidPeriodePesys(
+        isoCode = land!!,
+        fra = fomDato,
+        til = tomDato,
+        poengInnAar = poengIInnAr,
+        poengUtAar = poengIUtAr,
+        prorata = ikkeProRata?.not(),
+        kilde = kilde,
+    )
+
+private fun TrygdetidPeriodePesys.fraPesystilVanlig(): TrygdetidPeriode =
+    TrygdetidPeriode(
+        fra = fra,
+        til = til,
+    )
+
+private const val AUTOMATISK_FREMTIDIG_BEGRUNNELSE = "Automatisk beregnet fremtidig trygdetid"
+
+class TrygdetidServiceImpl(
+    private val trygdetidRepository: TrygdetidRepository,
+    private val behandlingKlient: BehandlingKlient,
+    private val grunnlagKlient: GrunnlagKlient,
+    private val beregnTrygdetidService: TrygdetidBeregningService,
+    private val pesysKlient: PesysKlient,
+    private val avtaleService: AvtaleService,
+    private val vedtaksvurderingKlient: VedtaksvurderingKlient,
+    private val featureToggleService: FeatureToggleService,
+) : TrygdetidService {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    companion object {
+        private const val SIST_FREMTIDIG_TRYGDETID_ALDER = 66L
+    }
+
+    override suspend fun hentTrygdetiderIBehandling(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid> =
+        trygdetidRepository
+            .hentTrygdetiderForBehandling(behandlingId)
+            .mapNotNull { trygdetid -> sjekkTrygdetidMotGrunnlag(trygdetid, brukerTokenInfo) }
+            .sortedBy { it.ident }
+
+    override suspend fun hentTrygdetidIBehandlingMedId(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid? =
+        trygdetidRepository
+            .hentTrygdetidMedId(behandlingId, trygdetidId)
+            ?.let { trygdetid -> sjekkTrygdetidMotGrunnlag(trygdetid, brukerTokenInfo) }
+
+    override suspend fun opprettTrygdetiderForBehandling(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+        overskriv: Boolean,
+    ): List<Trygdetid> =
+        kanOppdatereTrygdetid(
+            behandlingId,
+            brukerTokenInfo,
+        ) {
+            val avdoede = grunnlagKlient.hentGrunnlag(behandlingId, brukerTokenInfo).hentAvdoede()
+            val eksisterendeTrygdetider =
+                trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).let { trygdetider ->
+                    if (overskriv) {
+                        trygdetider
+                            .forEach { trygdetid -> trygdetidRepository.slettTrygdetid(trygdetid.id) }
+                        emptyList()
+                    } else {
+                        trygdetider
+                    }
+                }
+
+            if (eksisterendeTrygdetider.isNotEmpty() && avdoede.size == eksisterendeTrygdetider.size) {
+                throw TrygdetidAlleredeOpprettetException()
+            }
+
+            val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+
+            when (behandling.behandlingType) {
+                BehandlingType.FØRSTEGANGSBEHANDLING -> {
+                    val ukjentAvdoed = avdoede.isEmpty()
+                    val tidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar ?: false
+
+                    if (ukjentAvdoed || tidligereFamiliepleier) {
+                        logger.info(
+                            "Oppretter overstyrt trygdetid for behandling $behandlingId " +
+                                "(ukjentAvdoed=$ukjentAvdoed, tidligereFamiliepleier=$tidligereFamiliepleier)",
+                        )
+                        listOf(opprettOverstyrtBeregnetTrygdetid(behandlingId, true, brukerTokenInfo))
+                    } else {
+                        logger.info("Oppretter trygdetid for behandling $behandlingId")
+                        opprettTrygdetiderForBehandling(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+                    }
+                }
+
+                BehandlingType.REVURDERING -> {
+                    val sisteIverksatteBehandling =
+                        vedtaksvurderingKlient
+                            .hentIverksatteVedtak(behandling.sak, brukerTokenInfo)
+                            .sortedByDescending { it.datoAttestert }
+                            .first { it.vedtakType != VedtakType.OPPHOER } // Opphør har ikke trygdetid
+                    val forrigeTrygdetider =
+                        hentTrygdetiderIBehandling(sisteIverksatteBehandling.behandlingId, brukerTokenInfo)
+                    if (forrigeTrygdetider.isEmpty()) {
+                        opprettTrygdetiderForRevurdering(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+                    } else {
+                        val kopierteTrygdetider =
+                            kopierSisteTrygdetidberegninger(behandling, forrigeTrygdetider, eksisterendeTrygdetider)
+                        kopierAvtale(behandling.id, sisteIverksatteBehandling.behandlingId)
+
+                        opprettTrygdetiderForRevurdering(behandling, kopierteTrygdetider, avdoede, brukerTokenInfo)
+
+                        // Vi har oppdatert trydgetiden i databasen, henter på nytt
+                        hentTrygdetiderIBehandling(behandlingId, brukerTokenInfo)
+                    }
+                }
+            }
+        }.also { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo) }
+
+    private suspend fun opprettTrygdetiderForRevurdering(
+        behandling: DetaljertBehandling,
+        eksisterendeTrygdetider: List<Trygdetid>,
+        avdoede: List<Grunnlagsdata<JsonNode>>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid> =
+        if (behandling.revurderingsaarsak == Revurderingaarsak.REGULERING &&
+            behandling.prosesstype == Prosesstype.AUTOMATISK
+        ) {
+            logger.info("Forrige trygdetid for ${behandling.id} finnes ikke - må reguleres manuelt")
+            throw ManglerForrigeTrygdetidMaaReguleresManuelt()
+        } else {
+            logger.info("Oppretter trygdetid for behandling ${behandling.id} revurdering")
+            opprettTrygdetiderForBehandling(behandling, eksisterendeTrygdetider, avdoede, brukerTokenInfo)
+        }
+
+    /**
+     * Vi har sett en sak der trydgetiden på forrige iverksatte behandling er feil. Dermed trenger vi å ikke kopiere
+     * med denne feilen videre i neste behandling.
+     *
+     * Se porten-sak FAGSYSTEM-425200
+     */
+    private fun ryddBortKopiertTrygdetidMedDaarligData(
+        behandling: DetaljertBehandling,
+        eksisterendeTrygdetider: List<Trygdetid>,
+        avdoede: List<Grunnlagsdata<JsonNode>>,
+    ): List<Trygdetid> {
+        if (behandling.sakType != SakType.OMSTILLINGSSTOENAD) {
+            return eksisterendeTrygdetider
+        }
+        if (eksisterendeTrygdetider.size != 1) {
+            return eksisterendeTrygdetider
+        }
+        val eksisterendeTrygdetid = eksisterendeTrygdetider.single()
+        if (eksisterendeTrygdetid.ident != UKJENT_AVDOED) {
+            return eksisterendeTrygdetider
+        }
+        if (avdoede.isEmpty()) {
+            return eksisterendeTrygdetider
+        }
+        if (avdoede.any { it.hentFoedselsnummer()?.verdi?.value == null }) {
+            logger.error(
+                "Vi har en OMS-sak med UKJENT_AVDOED, og mangler kjent avdød i grunnlaget. Trygedtid er " +
+                    "sannsynligvis ikke bra i denne saken. SakId = ${behandling.sak.sakId}, behandlingId = ${behandling.id}. " +
+                    "Denne bør følges opp av et menneske for å se om behandlingen blir riktig, og eventuelt om det trengs " +
+                    "å få på plass riktig avdød i saken.",
+            )
+            return eksisterendeTrygdetider
+        }
+        // Hvis vi har en OMS sak der vi har kun en kopiert trygedtid med ukjent avdød, og vi har en gyldig avdød i
+        // grunnlaget i saken, kan vi bare rydde bort den kopierte trygdetiden med UKJENT_AVDOED, siden den er broken
+        trygdetidRepository.slettTrygdetid(eksisterendeTrygdetid.id)
+        return emptyList()
+    }
+
+    private suspend fun opprettTrygdetiderForBehandling(
+        behandling: DetaljertBehandling,
+        eksisterendeTrygdetider: List<Trygdetid>,
+        avdoede: List<Grunnlagsdata<JsonNode>>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid> {
+        val eksisterendeTrygdetidEtterRydding =
+            ryddBortKopiertTrygdetidMedDaarligData(behandling, eksisterendeTrygdetider, avdoede)
+
+        return avdoede
+            .map { avdoed ->
+                val fnr =
+                    krevIkkeNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
+                        "Kunne ikke hente identifikator for avdød til trygdetid i " +
+                            "behandlingen med id=${behandling.id}"
+                    }
+
+                Pair(fnr, avdoed)
+            }.filter { avdoedMedFnr ->
+                eksisterendeTrygdetidEtterRydding.none { avdoedMedFnr.first == it.ident }
+            }.map { avdoedMedFnr ->
+                val trygdetid =
+                    Trygdetid(
+                        sakId = behandling.sak,
+                        behandlingId = behandling.id,
+                        opplysninger = hentOpplysninger(avdoedMedFnr.second, behandling.id),
+                        ident = avdoedMedFnr.first,
+                        yrkesskade = false,
+                    )
+
+                val opprettetTrygdetid = trygdetidRepository.opprettTrygdetid(trygdetid)
+
+                val oppdatertTrygdetid =
+                    opprettFremtidigTrygdetidForAvdoed(opprettetTrygdetid, avdoedMedFnr.second, brukerTokenInfo)
+
+                oppdatertTrygdetid ?: opprettetTrygdetid
+            }.also {
+                logger.info("Opprettet ${it.size} trygdetider for behandling=${behandling.id}")
+            }
+    }
+
+    override suspend fun harTrygdetidsgrunnlagIPesysForApOgUfoere(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean {
+        val avdoede = grunnlagKlient.hentGrunnlag(behandlingId, brukerTokenInfo).hentAvdoede()
+        val perioderIPesys =
+            avdoede
+                .map { avdoed ->
+                    val fnr =
+                        sjekkIkkeNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
+                            "Kunne ikke hente identifikator for avdød til trygdetid i " +
+                                "behandlingen med id=$behandlingId"
+                        }
+
+                    Pair(fnr, avdoed)
+                }.map { avdoedMedFnr ->
+                    val doedsdato =
+                        avdoedMedFnr.second.hentDoedsdato()?.verdi
+                            ?: throw UgyldigForespoerselException("INGEN_AVDOEDE", "Avdød mangler dødsdato")
+                    val trygdetidForUfoereOgAlderspensjon =
+                        pesysKlient.hentTrygdetidsgrunnlag(
+                            Pair(avdoedMedFnr.first, doedsdato),
+                            brukerTokenInfo,
+                        )
+                    trygdetidForUfoereOgAlderspensjon
+                }.map {
+                    mapTrygdetidsgrunnlagFraPesys(it)
+                }
+        return perioderIPesys.flatten().isNotEmpty()
+    }
+
+    override suspend fun leggInnTrygdetidsgrunnlagFraPesys(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid> {
+        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+        if (!behandling.status.kanEndres()) {
+            throw UgyldigForespoerselException(
+                code = "UGYLDIG_TILSTAND_TRYGDETID",
+                detail = "Kan ikke opprette/endre trygdetid da behandlingen er i feil tilstand",
+            )
+        }
+        val avdoede = grunnlagKlient.hentGrunnlag(behandlingId, brukerTokenInfo).hentAvdoede()
+        when (behandling.behandlingType) {
+            BehandlingType.FØRSTEGANGSBEHANDLING -> {
+                val ukjentAvdoed = avdoede.isEmpty()
+                val tidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar ?: false
+
+                if (ukjentAvdoed || tidligereFamiliepleier) {
+                    throw InternfeilException("Støtter ikke pesys henting for ukjent avdød eller tidligere Familiepleier")
+                }
+            }
+
+            else -> {
+                throw InternfeilException("Kan kun hente inn trygdetider for førstegangsbehandling")
+            }
+        }
+
+        return avdoede
+            .map { avdoed ->
+                val fnr =
+                    krevIkkeNull(avdoed.hentFoedselsnummer()?.verdi?.value) {
+                        "Kunne ikke hente identifikator for avdød til trygdetid i " +
+                            "behandlingen med id=$behandlingId"
+                    }
+
+                Pair(fnr, avdoed)
+            }.map { avdoedMedFnr ->
+                val hentTrygdetid =
+                    trygdetidRepository.hentTrygdetid(behandlingId)
+                        ?: throw InternfeilException("Trygdetid er ikke opprettet")
+                val doedsdato =
+                    avdoedMedFnr.second.hentDoedsdato()?.verdi ?: throw InternfeilException("Avdød mangler dødsdato")
+
+                val trygdetidForUfoereOgAlderspensjon =
+                    pesysKlient.hentTrygdetidsgrunnlag(
+                        Pair(avdoedMedFnr.first, doedsdato),
+                        brukerTokenInfo,
+                    )
+
+                val hentetTrygdetidMedPesysTrygdetid =
+                    populerTrygdetidsGrunnlagFraPesys(hentTrygdetid, trygdetidForUfoereOgAlderspensjon)
+                trygdetidRepository.oppdaterTrygdetid(hentetTrygdetidMedPesysTrygdetid)
+                val oppdatertTrygdetid =
+                    opprettFremtidigTrygdetidForAvdoed(
+                        hentetTrygdetidMedPesysTrygdetid,
+                        avdoedMedFnr.second,
+                        brukerTokenInfo,
+                    )
+
+                oppdatertTrygdetid ?: hentetTrygdetidMedPesysTrygdetid
+            }
+    }
+
+    private fun populerTrygdetidsGrunnlagFraPesys(
+        trygdetid: Trygdetid,
+        pesysTrygdetidsgrunnlag: TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon,
+    ): Trygdetid = trygdetid.copy(trygdetidGrunnlag = mapTrygdetidsgrunnlagFraPesys(pesysTrygdetidsgrunnlag))
+
+    private fun mapTrygdetidsgrunnlagFraPesys(
+        pesysTrygdetidsgrunnlag: TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon,
+    ): List<TrygdetidGrunnlag> {
+        val mappedAlderspensjonTrygdetidsgrunnlag =
+            pesysTrygdetidsgrunnlag.trygdetidAlderspensjon?.trygdetidsgrunnlagListe?.trygdetidsgrunnlagListe?.map {
+                mapPesysTrygdetidsgrunnlag(it, Grunnlagsopplysning.Alderspensjon.create())
+            } ?: emptyList()
+
+        val mappedUfoereTrygdetidsgrunnlag =
+            pesysTrygdetidsgrunnlag.trygdetidUfoeretrygdpensjon?.trygdetidsgrunnlagListe?.trygdetidsgrunnlagListe?.map {
+                mapPesysTrygdetidsgrunnlag(it, Grunnlagsopplysning.Ufoeretrygd.create())
+            } ?: emptyList()
+
+        if (mappedAlderspensjonTrygdetidsgrunnlag.isNotEmpty()) {
+            return mappedAlderspensjonTrygdetidsgrunnlag
+        } else if (mappedUfoereTrygdetidsgrunnlag.isNotEmpty()) {
+            return mappedUfoereTrygdetidsgrunnlag
+        }
+        logger.info("Fant ingen trygdtidsgrunnlag som vi kunne mappe over")
+        return emptyList()
+    }
+
+    private fun mapPesysTrygdetidsgrunnlag(
+        tt: Trygdetidsgrunnlag,
+        kilde: Grunnlagsopplysning.PesysYtelseKilde,
+    ): TrygdetidGrunnlag {
+        val trygdetidsperiode = tt.tilTrygdetidsPeriode(kilde)
+        return TrygdetidGrunnlag(
+            id = UUID.randomUUID(),
+            type = TrygdetidType.FAKTISK,
+            bosted = tt.land ?: "Ukjent",
+            periode = trygdetidsperiode.fraPesystilVanlig(),
+            kilde = trygdetidsperiode.kilde,
+            beregnetTrygdetid = null,
+            poengUtAar = trygdetidsperiode.poengUtAar == true,
+            poengInnAar = trygdetidsperiode.poengInnAar == true,
+            prorata = trygdetidsperiode.prorata == true,
+            begrunnelse = null,
+        )
+    }
+
+    private suspend fun opprettFremtidigTrygdetidForAvdoed(
+        trygdetid: Trygdetid,
+        avdoed: Grunnlagsdata<JsonNode>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ) = beregnfremtidigTrygdetidsPeriode(avdoed)?.let { periode ->
+        lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandling(
+            trygdetid.behandlingId,
+            trygdetid.id,
+            TrygdetidGrunnlag(
+                id = UUID.randomUUID(),
+                type = TrygdetidType.FREMTIDIG,
+                bosted = LandNormalisert.NORGE.isoCode,
+                periode = periode,
+                kilde =
+                    Grunnlagsopplysning.Saksbehandler(
+                        Grunnlagsopplysning.automatiskSaksbehandler.ident,
+                        Tidspunkt.now(),
+                    ),
+                begrunnelse = AUTOMATISK_FREMTIDIG_BEGRUNNELSE,
+                poengInnAar = false,
+                poengUtAar = false,
+                prorata = false,
+            ),
+            brukerTokenInfo,
+        )
+    }
+
+    private fun beregnfremtidigTrygdetidsPeriode(avdoed: Grunnlagsdata<JsonNode>): TrygdetidPeriode? {
+        val doedsDato = avdoed.hentDoedsdato()?.verdi
+
+        val sistFremtidigDato =
+            avdoed
+                .hentFoedselsdato()
+                ?.verdi
+                ?.plusYears(
+                    SIST_FREMTIDIG_TRYGDETID_ALDER,
+                )?.with(TemporalAdjusters.firstDayOfNextYear())
+                ?.minusDays(1)
+
+        return if (doedsDato != null && sistFremtidigDato != null && doedsDato.isBefore(sistFremtidigDato)) {
+            TrygdetidPeriode(doedsDato, sistFremtidigDato)
+        } else {
+            null
+        }
+    }
+
+    override suspend fun lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandlingMedSjekk(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        trygdetidGrunnlag: TrygdetidGrunnlag,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            // Hvis vi oppdaterer en trygdetid som har automatisk begrunnelse, fjern automatisk begrunnelse
+            val trygdetidGrunnlagForOppdatering =
+                when (trygdetidGrunnlag.begrunnelse) {
+                    AUTOMATISK_FREMTIDIG_BEGRUNNELSE -> trygdetidGrunnlag.copy(begrunnelse = null)
+                    else -> trygdetidGrunnlag
+                }
+
+            lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandling(
+                behandlingId,
+                trygdetidId,
+                trygdetidGrunnlagForOppdatering,
+                brukerTokenInfo,
+            )
+        }
+
+    private suspend fun lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandling(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        trygdetidGrunnlag: TrygdetidGrunnlag,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid {
+        val gjeldendeTrygdetid: Trygdetid =
+            trygdetidRepository.hentTrygdetidMedId(behandlingId, trygdetidId) ?: throw GenerellIkkeFunnetException()
+
+        val trygdetidGrunnlagBeregnet: TrygdetidGrunnlag =
+            trygdetidGrunnlag.oppdaterBeregnetTrygdetid(
+                beregnetTrygdetid = beregnTrygdetidService.beregnTrygdetidGrunnlag(trygdetidGrunnlag),
+            )
+
+        val trygdetidMedOppdatertTrygdetidGrunnlag: Trygdetid =
+            gjeldendeTrygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(trygdetidGrunnlagBeregnet)
+
+        return oppdaterBeregnetTrygdetid(behandlingId, trygdetidMedOppdatertTrygdetidGrunnlag, brukerTokenInfo)
+    }
+
+    private data class DatoerForBehandling(
+        val foedselsDato: LocalDate,
+        val doedsDato: LocalDate,
+    )
+
+    private fun hentDatoerForBehandling(trygdetid: Trygdetid): DatoerForBehandling =
+        DatoerForBehandling(
+            toLocalDate(trygdetid.opplysninger.firstOrNull { it.type == TrygdetidOpplysningType.FOEDSELSDATO })
+                ?: throw IngenFoedselsdatoForAvdoedFunnet(trygdetid.id),
+            toLocalDate(trygdetid.opplysninger.firstOrNull { it.type == TrygdetidOpplysningType.DOEDSDATO })
+                ?: throw IngenDoedsdatoForAvdoedFunnet(trygdetid.id),
+        )
+
+    override suspend fun slettTrygdetidGrunnlagForTrygdetid(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        trygdetidGrunnlagId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            val trygdetid =
+                trygdetidRepository
+                    .hentTrygdetidMedId(behandlingId, trygdetidId)
+                    ?.slettTrygdetidGrunnlag(trygdetidGrunnlagId)
+                    ?: throw Exception("Fant ikke gjeldende trygdetid for behandlingId=$behandlingId")
+
+            oppdaterBeregnetTrygdetid(behandlingId, trygdetid, brukerTokenInfo)
+        }
+
+    override suspend fun slettPesysTrygdetidGrunnlagForTrygdetid(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            val trygdetid =
+                trygdetidRepository
+                    .hentTrygdetidMedId(behandlingId, trygdetidId)
+                    ?: throw Exception("Fant ikke gjeldende trygdetid for behandlingId=$behandlingId")
+
+            val altUnntattPesysKildeGrunnlag =
+                trygdetid.copy(
+                    trygdetidGrunnlag =
+                        trygdetid.trygdetidGrunnlag.filter {
+                            when (it.kilde) {
+                                is Grunnlagsopplysning.PesysYtelseKilde -> false
+                                else -> true
+                            }
+                        },
+                )
+            oppdaterBeregnetTrygdetid(behandlingId, altUnntattPesysKildeGrunnlag, brukerTokenInfo)
+        }
+
+    override suspend fun kopierSisteTrygdetidberegninger(
+        behandlingId: UUID,
+        forrigeBehandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid> {
+        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+
+        logger.info("Kopierer trygdetid for behandling ${behandling.id} fra behandling $forrigeBehandlingId")
+
+        kopierAvtale(behandlingId, forrigeBehandlingId)
+
+        val forrigeTrygdetid = hentTrygdetiderIBehandling(forrigeBehandlingId, brukerTokenInfo)
+        val eksisterendeTrygdetider = hentTrygdetiderIBehandling(behandlingId, brukerTokenInfo)
+
+        if (eksisterendeTrygdetider.isNotEmpty()) { // Interessert i om dette forekommer noen gang
+            logger.info(
+                "Det eksisterer trygdetider fra før ved kopiering av trygdetider " +
+                    "fra behandling $forrigeBehandlingId til $behandlingId",
+            )
+        }
+
+        val alleTrygdetider =
+            kopierSisteTrygdetidberegninger(behandling, forrigeTrygdetid, eksisterendeTrygdetider)
+
+        alleTrygdetider.forEach { trygdetid ->
+            val erOverstyrt = trygdetid.beregnetTrygdetid?.resultat?.overstyrt == true
+            if (!erOverstyrt && behandling.prosesstype != Prosesstype.AUTOMATISK) {
+                oppdaterBeregnetTrygdetid(behandlingId, trygdetid, brukerTokenInfo)
+            } else {
+                behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)
+            }
+        }
+        return alleTrygdetider
+    }
+
+    private fun kopierAvtale(
+        behandlingId: UUID,
+        forrigeBehandlingId: UUID,
+    ) {
+        val avtale =
+            avtaleService
+                .hentAvtaleForBehandling(forrigeBehandlingId)
+                ?.copy(id = UUID.randomUUID(), behandlingId = behandlingId)
+
+        if (avtale == null) {
+            logger.info("Fant ingen avtale på forrigeBehandling – hopper over kopiering av avtale")
+        } else {
+            logger.info("Kopierer avtale fra forrigeBehandling=$forrigeBehandlingId til nyBehandling=$behandlingId")
+
+            avtaleService.opprettAvtale(avtale)
+        }
+    }
+
+    private fun kopierSisteTrygdetidberegninger(
+        behandling: DetaljertBehandling,
+        forrigeTrygdetider: List<Trygdetid>,
+        eksisterendeTrygdetider: List<Trygdetid>,
+    ): List<Trygdetid> {
+        logger.info(
+            "Kopierer trygdetid for behandling ${behandling.id} fra " +
+                "trygdetider med id ${forrigeTrygdetider.joinToString { it.id.toString() }}",
+        )
+
+        // kopiere trygdetid fra forrige behandling til ny behandling
+        // vi ønsker ikke kopiere trygdetid for ident som allerede ligger på ny behandling, derfor filtrerer vi de ut
+        val forrigeTrydetiderIkkeKopiert =
+            forrigeTrygdetider
+                .filter { forrigeTrygdetid ->
+                    eksisterendeTrygdetider.none { it.ident == forrigeTrygdetid.ident }
+                }
+
+        val opprettetTrygdetider =
+            forrigeTrydetiderIkkeKopiert
+                .map { forrigeTrygdetid ->
+                    val kopiertTrygdetid =
+                        Trygdetid(
+                            sakId = behandling.sak,
+                            behandlingId = behandling.id,
+                            opplysninger = forrigeTrygdetid.opplysninger.map { it.copy(id = UUID.randomUUID()) },
+                            trygdetidGrunnlag = forrigeTrygdetid.trygdetidGrunnlag.map { it.copy(id = UUID.randomUUID()) },
+                            beregnetTrygdetid = forrigeTrygdetid.beregnetTrygdetid,
+                            ident = forrigeTrygdetid.ident,
+                            yrkesskade = forrigeTrygdetid.yrkesskade,
+                            overstyrtNorskPoengaar = forrigeTrygdetid.overstyrtNorskPoengaar,
+                            kopiertGrunnlagFraBehandling = forrigeTrygdetid.behandlingId,
+                            begrunnelse = forrigeTrygdetid.begrunnelse,
+                        )
+
+                    trygdetidRepository.opprettTrygdetid(kopiertTrygdetid)
+                }
+
+        return eksisterendeTrygdetider + opprettetTrygdetider
+    }
+
+    private fun kildeFoedselsnummer(): Grunnlagsopplysning.RegelKilde =
+        Grunnlagsopplysning.RegelKilde(
+            "Beregnet basert på fødselsdato fra pdl",
+            Tidspunkt.now(),
+            "1",
+        )
+
+    private fun hentOpplysninger(
+        avdoed: Grunnlagsdata<JsonNode>,
+        behandlingId: UUID,
+    ): List<Opplysningsgrunnlag> {
+        val avodedDoedsdato = avdoed.hentDoedsdato()
+
+        val avdoededsDatoOpplysning =
+            avodedDoedsdato?.verdi?.let {
+                Opplysningsgrunnlag.ny(TrygdetidOpplysningType.DOEDSDATO, avodedDoedsdato.kilde, it)
+            }
+
+        val foedselsdato = avdoed.hentFoedselsdato()
+        val foedselsdatoVerdi =
+            foedselsdato?.verdi ?: throw TrygdetidMaaHaFoedselsdatoException(behandlingId)
+
+        return listOfNotNull(
+            Opplysningsgrunnlag.ny(
+                TrygdetidOpplysningType.FOEDSELSDATO,
+                foedselsdato.kilde,
+                foedselsdatoVerdi,
+            ),
+            Opplysningsgrunnlag.ny(
+                TrygdetidOpplysningType.FYLT_16,
+                kildeFoedselsnummer(),
+                // Ifølge paragraf § 3-5 regnes trygdetid fra tidspunkt en person er fylt 16 år
+                foedselsdatoVerdi.plusYears(16),
+            ),
+            Opplysningsgrunnlag.ny(
+                TrygdetidOpplysningType.FYLLER_66,
+                kildeFoedselsnummer(),
+                // Ifølge paragraf § 3-5 regnes trygdetid frem til tidspunkt en person er fyller 66 pår
+                foedselsdatoVerdi.plusYears(SIST_FREMTIDIG_TRYGDETID_ALDER),
+            ),
+            avdoededsDatoOpplysning,
+        )
+    }
+
+    private suspend fun <T> kanOppdatereTrygdetid(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+        block: suspend () -> T,
+    ): T {
+        val kanFastsetteTrygdetid = behandlingKlient.kanOppdatereTrygdetid(behandlingId, brukerTokenInfo)
+        return if (kanFastsetteTrygdetid) {
+            block()
+        } else {
+            logger.info("Kan ikke opprette/endre trygdetid da behandlingen med id=$behandlingId er i feil tilstand")
+
+            throw UgyldigForespoerselException(
+                code = "UGYLDIG_TILSTAND_TRYGDETID",
+                detail = "Kan ikke opprette/endre trygdetid da behandlingen er i feil tilstand",
+            )
+        }
+    }
+
+    override suspend fun opprettOverstyrtBeregnetTrygdetid(
+        behandlingId: UUID,
+        overskriv: Boolean,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid {
+        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+
+        // Merk: vi kan ikke bruke den vanlige sjekken på kanOppdatereTrygdetid, siden dette kallet skjer typisk
+        // når behandlingen akkurat er opprettet. Men det er viktig at vi ikke tillater endringer hvis behandlingen
+        // ikke kan endres.
+        if (behandling.status !in BehandlingStatus.kanEndres()) {
+            throw IkkeTillattException(
+                "BEHANLDING_KAN_IKKE_ENDRES",
+                "Kan ikke opprette overstyrt trygdetid i en behandling som ikke kan endres",
+            )
+        }
+
+        val trygdetider = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
+
+        if (trygdetider.isNotEmpty()) {
+            if (overskriv) {
+                logger.warn("Sletter ${trygdetider.size} trygdetid(er) for behandling (id=$behandlingId)")
+                trygdetider.forEach { trygdetidRepository.slettTrygdetid(it.id) }
+            } else {
+                throw TrygdetidAlleredeOpprettetException()
+            }
+        }
+        logger.info("Oppretter manuell overstyrt trygdetid for behandling $behandlingId")
+
+        val avdoede =
+            grunnlagKlient
+                .hentGrunnlag(behandling.id, brukerTokenInfo)
+                .hentAvdoede()
+        val avdoed =
+            if (avdoede.isNotEmpty()) {
+                val avdoedViKoblerTrygdetidPaa =
+                    if (avdoede.size == 1) {
+                        avdoede.first()
+                    } else {
+                        // TODO: Det er mest sannsynlig den med tidligst dødsdato som er aktuell,
+                        //   men det er muligens behov for å overstyre trygdetiden til en eller flere avdøde,
+                        //   og dette burde bli angitt i requesten.
+                        //   slik det er nå får man ikke muliggheten til å godt overstyre trygdetiden hvis det er
+                        //   flere avdøde i saken og man trenger flere ulike perioder for de to avdøde.
+                        avdoede.minBy { it.hentDoedsdato()?.verdi ?: LocalDate.MAX }
+                    }
+                if (avdoedViKoblerTrygdetidPaa.hentDoedsdato()?.verdi == null) {
+                    throw UgyldigForespoerselException(
+                        "KJENT_AVDOED_MANGLER_DOEDSDATO",
+                        "Persongalleriet inneholder en kjent avdød som ikke har en dødsdato registrert. For å " +
+                            "overstyre trygdetid i saken må avdød angitt i persongalleriet få registrert en dødsdato " +
+                            "eller persongalleriet må rettes på.",
+                    )
+                } else {
+                    avdoedViKoblerTrygdetidPaa
+                }
+            } else {
+                null // ukjent avdød
+            }
+
+        val tidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar ?: false
+
+        val ident =
+            if (tidligereFamiliepleier) {
+                krevIkkeNull(behandling.soeker) {
+                    "Kunne ikke hente identifikator for soeker til trygdetid i " +
+                        "behandlingen med id=$behandlingId"
+                }
+            } else {
+                avdoed?.let {
+                    krevIkkeNull(it.hentFoedselsnummer()?.verdi?.value) {
+                        "Kunne ikke hente identifikator for avdød til trygdetid i " +
+                            "behandlingen med id=$behandlingId"
+                    }
+                } ?: UKJENT_AVDOED
+            }
+
+        val trygdetid =
+            Trygdetid(
+                sakId = behandling.sak,
+                behandlingId = behandlingId,
+                opplysninger = avdoed?.let { hentOpplysninger(it, behandlingId) } ?: emptyList(),
+                ident = ident,
+                trygdetidGrunnlag = emptyList(),
+                beregnetTrygdetid =
+                    DetaljertBeregnetTrygdetid(
+                        resultat =
+                            DetaljertBeregnetTrygdetidResultat(
+                                faktiskTrygdetidNorge = null,
+                                faktiskTrygdetidTeoretisk = null,
+                                fremtidigTrygdetidNorge = null,
+                                fremtidigTrygdetidTeoretisk = null,
+                                samletTrygdetidNorge = null,
+                                samletTrygdetidTeoretisk = null,
+                                prorataBroek = null,
+                                overstyrt = true,
+                                yrkesskade = false,
+                                beregnetSamletTrygdetidNorge = null,
+                            ),
+                        tidspunkt = Tidspunkt.now(),
+                        regelResultat = "".toJsonNode(),
+                    ),
+                yrkesskade = false,
+            )
+        return trygdetidRepository.opprettTrygdetid(trygdetid)
+    }
+
+    override suspend fun setYrkesskade(
+        trygdetidId: UUID,
+        behandlingId: UUID,
+        yrkesskade: Boolean,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            val trygdetid =
+                trygdetidRepository.hentTrygdetidMedId(behandlingId, trygdetidId)
+                    ?: throw TrygdetidIkkeFunnetForBehandling()
+
+            logger.info("Oppdatere yrkesskade $yrkesskade for trygdetid $trygdetidId for behandling $behandlingId")
+
+            oppdaterBeregnetTrygdetid(behandlingId, trygdetid.copy(yrkesskade = yrkesskade), brukerTokenInfo)
+        }
+
+    override suspend fun oppdaterTrygdetidMedBegrunnelse(
+        trygdetidId: UUID,
+        behandlingId: UUID,
+        begrunnelse: String?,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            val trygdetid =
+                trygdetidRepository
+                    .hentTrygdetidMedId(behandlingId, trygdetidId)
+                    ?: throw TrygdetidIkkeFunnetForBehandling()
+
+            trygdetidRepository
+                .oppdaterTrygdetid(trygdetid.oppdaterBegrunnelse(begrunnelse))
+                .let { sjekkTrygdetidMotGrunnlag(it, brukerTokenInfo)!! }
+        }
+
+    override fun overstyrBeregnetTrygdetidForAvdoed(
+        behandlingId: UUID,
+        ident: String,
+        beregnetTrygdetid: DetaljertBeregnetTrygdetidResultat,
+    ): Trygdetid {
+        val trygdetid =
+            trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).find { it.ident == ident }
+                ?: throw GenerellIkkeFunnetException()
+
+        val oppdatertTrygdetid =
+            trygdetid.copy(
+                trygdetidGrunnlag = emptyList(),
+                beregnetTrygdetid =
+                    DetaljertBeregnetTrygdetid(
+                        resultat = beregnetTrygdetid.copy(overstyrt = true),
+                        tidspunkt = Tidspunkt.now(),
+                        regelResultat = "".toJsonNode(),
+                    ),
+            )
+
+        return trygdetidRepository.oppdaterTrygdetid(oppdatertTrygdetid)
+    }
+
+    override suspend fun oppdaterOpplysningsgrunnlagForTrygdetider(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<Trygdetid> {
+        val trygdetidList = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
+        if (trygdetidList.isEmpty()) {
+            throw IngenTrygdetidFunnetForAvdoede()
+        }
+        val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+        logger.info("Oppdaterer opplysningsgrunnlag for trygdetider (behandlingId=$behandlingId)")
+
+        val avdoede = grunnlagKlient.hentGrunnlag(behandling.id, brukerTokenInfo).hentAvdoede()
+        return trygdetidList
+            .map { trygdetid -> medOppdaterteOpplysningerOmAvdoede(trygdetid, avdoede, behandlingId) }
+            .map { trygdetid -> oppdaterBeregnetTrygdetid(behandlingId, trygdetid, brukerTokenInfo) }
+    }
+
+    private fun medOppdaterteOpplysningerOmAvdoede(
+        trygdetid: Trygdetid,
+        avdoede: List<Grunnlagsdata<JsonNode>>,
+        behandlingId: UUID,
+    ) = trygdetid.copy(
+        opplysninger =
+            hentOpplysninger(
+                avdoede.first { it.hentFoedselsnummer()?.verdi?.value == trygdetid.ident },
+                behandlingId,
+            ),
+    )
+
+    override suspend fun sjekkGyldighetOgOppdaterBehandlingStatus(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            val trygdetider = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
+            val behandling = behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo)
+
+            if (trygdetider.isEmpty()) {
+                throw IngenTrygdetidFunnetForAvdoede()
+            }
+
+            if (trygdetider.any { it.beregnetTrygdetid == null }) {
+                throw TrygdetidManglerBeregning()
+            }
+
+            // Dersom forrige steg (vilkårsvurdering) har blitt endret vil statusen være VILKAARSVURDERT. Når man
+            // trykker videre fra vilkårsvurdering skal denne validere tilstand og sette status TRYGDETID_OPPDATERT.
+            if (behandling.status == BehandlingStatus.VILKAARSVURDERT) {
+                behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)
+            } else {
+                false
+            }
+        }
+
+    private suspend fun sjekkTrygdetidMotGrunnlag(
+        trygdetid: Trygdetid,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid? {
+        val soeker = grunnlagKlient.hentGrunnlag(trygdetid.behandlingId, brukerTokenInfo).soeker
+        if (trygdetid.ident == UKJENT_AVDOED || trygdetid.ident == soeker.hentFoedselsnummer()?.verdi?.value) {
+            return trygdetid
+                .copy(opplysningerDifferanse = OpplysningerDifferanse(false, GrunnlagOpplysningerDto.tomt()))
+        }
+        val nyAvdoedGrunnlag = grunnlagKlient.hentGrunnlag(trygdetid.behandlingId, brukerTokenInfo).hentAvdoede()
+        val avdoedeFnr = nyAvdoedGrunnlag.mapNotNull { it.hentFoedselsnummer()?.verdi?.value }
+        if (!avdoedeFnr.contains(trygdetid.ident)) {
+            trygdetidRepository.slettTrygdetid(trygdetid.id)
+            return null
+        }
+        return trygdetid.copy(
+            opplysningerDifferanse =
+                finnOpplysningerDifferanse(
+                    trygdetid,
+                    nyAvdoedGrunnlag.firstOrNull { it.hentFoedselsnummer()?.verdi?.value == trygdetid.ident },
+                ),
+        )
+    }
+
+    private fun finnOpplysningerDifferanse(
+        trygdetid: Trygdetid,
+        nyAvdoedGrunnlag: Grunnlagsdata<JsonNode>?,
+    ): OpplysningerDifferanse {
+        if (
+            trygdetid.beregnetTrygdetid
+                ?.resultat
+                ?.overstyrt
+                .let { it != null && it }
+        ) {
+            return OpplysningerDifferanse(
+                differanse = false,
+                GrunnlagOpplysningerDto.tomt(),
+            )
+        }
+
+        val nyeOpplysninger =
+            if (nyAvdoedGrunnlag != null) hentOpplysninger(nyAvdoedGrunnlag, trygdetid.behandlingId) else emptyList()
+
+        if (nyeOpplysninger.isEmpty() && trygdetid.opplysninger.isEmpty()) {
+            return OpplysningerDifferanse(false, GrunnlagOpplysningerDto(null, null, null, null))
+        }
+
+        val nyFoedselsdato = nyeOpplysninger.firstOrNull { it.type == TrygdetidOpplysningType.FOEDSELSDATO }
+        val nyDoedsdato = nyeOpplysninger.firstOrNull { it.type == TrygdetidOpplysningType.DOEDSDATO }
+        val nyFylt16 = nyeOpplysninger.firstOrNull { it.type == TrygdetidOpplysningType.FYLT_16 }
+        val nyFyller66 = nyeOpplysninger.firstOrNull { it.type == TrygdetidOpplysningType.FYLLER_66 }
+
+        val eksisterendeFoedselsdato =
+            trygdetid.opplysninger.firstOrNull { it.type == TrygdetidOpplysningType.FOEDSELSDATO }
+        val eksisterendeDoedsdato = trygdetid.opplysninger.firstOrNull { it.type == TrygdetidOpplysningType.DOEDSDATO }
+        val eksisterendeFylt16 = trygdetid.opplysninger.firstOrNull { it.type == TrygdetidOpplysningType.FYLT_16 }
+        val eksisterendeFyller66 = trygdetid.opplysninger.firstOrNull { it.type == TrygdetidOpplysningType.FYLLER_66 }
+        val diff =
+            toLocalDate(nyFoedselsdato) != toLocalDate(eksisterendeFoedselsdato) ||
+                toLocalDate(nyDoedsdato) != toLocalDate(eksisterendeDoedsdato) ||
+                toLocalDate(nyFylt16) != toLocalDate(eksisterendeFylt16) ||
+                toLocalDate(nyFyller66) != toLocalDate(eksisterendeFyller66)
+
+        return OpplysningerDifferanse(
+            diff,
+            nyeOpplysninger.toDto(),
+        )
+    }
+
+    private fun toLocalDate(opplysningsgrunnlag: Opplysningsgrunnlag?): LocalDate? =
+        opplysningsgrunnlag?.let {
+            objectMapper.readValue(it.opplysning.toString())
+        }
+
+    override suspend fun overstyrNorskPoengaaarForTrygdetid(
+        trygdetidId: UUID,
+        behandlingId: UUID,
+        overstyrtNorskPoengaar: Int?,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            val trygdetid =
+                trygdetidRepository.hentTrygdetidMedId(behandlingId, trygdetidId)
+                    ?: throw GenerellIkkeFunnetException()
+
+            oppdaterBeregnetTrygdetid(
+                behandlingId,
+                trygdetid.copy(overstyrtNorskPoengaar = overstyrtNorskPoengaar),
+                brukerTokenInfo,
+            )
+        }
+
+    private suspend fun oppdaterBeregnetTrygdetid(
+        behandlingId: UUID,
+        trygdetid: Trygdetid,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Trygdetid {
+        val datoer = hentDatoerForBehandling(trygdetid)
+        val nordiskKonvensjon = avtaleService.hentAvtaleForBehandling(behandlingId)?.nordiskTrygdeAvtale == JaNei.JA
+
+        val nyBeregnetTrygdetid =
+            beregnTrygdetidService.beregnTrygdetid(
+                trygdetidGrunnlag = trygdetid.trygdetidGrunnlag,
+                datoer.foedselsDato,
+                datoer.doedsDato,
+                trygdetid.overstyrtNorskPoengaar,
+                trygdetid.yrkesskade,
+                nordiskKonvensjon,
+            )
+        return when (nyBeregnetTrygdetid) {
+            null -> trygdetid.nullstillBeregnetTrygdetid()
+            else -> trygdetid.oppdaterBeregnetTrygdetid(nyBeregnetTrygdetid)
+        }.also { nyTrygdetid ->
+            trygdetidRepository.oppdaterTrygdetid(nyTrygdetid)
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, brukerTokenInfo)
+        }
+    }
+
+    override suspend fun kopierOgOverskrivTrygdetid(
+        behandlingId: UUID,
+        kildeBehandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<TrygdetidDto> =
+        kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
+            logger.info("Kopierer trygdetidsgrunnlag for behandling $behandlingId fra behandling $kildeBehandlingId")
+            val trygdetiderMaal = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
+            val trygdetiderKilde = trygdetidRepository.hentTrygdetiderForBehandling(kildeBehandlingId)
+            sjekkAtTrygdetideneGjelderSammeAvdoede(trygdetiderMaal, trygdetiderKilde, behandlingId, kildeBehandlingId)
+
+            trygdetiderMaal.forEach { trygdetidRepository.slettTrygdetid(it.id) }
+
+            kopierSisteTrygdetidberegninger(behandlingId, kildeBehandlingId, brukerTokenInfo)
+
+            hentTrygdetiderIBehandling(behandlingId, brukerTokenInfo)
+                .map { it.toDto() }
+        }
+
+    override suspend fun finnBehandlingMedTrygdetidForSammeAvdoede(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): UUID? {
+        val avdoede: List<Folkeregisteridentifikator> =
+            grunnlagKlient
+                .hentGrunnlag(behandlingId, brukerTokenInfo)
+                .hentAvdoede()
+                .mapNotNull { it.hentFoedselsnummer()?.verdi }
+        if (avdoede.isEmpty()) {
+            return null
+        }
+
+        if (!lagredeTrygdetiderHarSammeAvdoede(behandlingId, avdoede)) {
+            logger.warn(
+                "Avdøde i grunnlag stemmer ikke med avdøde i trygdetider. " +
+                    "Returnerer ingen behandling med trygdetid for samme avdøde.",
+            )
+            return null
+        }
+
+        return behandlingMedTrygdetiderForAvdoede(avdoede)
+            .filter { it != behandlingId }
+            .firstOrNull { behandlingStatusOkForKopieringAvTrygdetid(it, brukerTokenInfo) }
+    }
+
+    private fun behandlingMedTrygdetiderForAvdoede(avdoedeList: List<Folkeregisteridentifikator>): List<UUID> {
+        val avdoede = avdoedeList.map { it.value }
+        val trygdetiderByBehandlingId: Collection<List<TrygdetidPartial>> =
+            trygdetidRepository
+                .hentTrygdetiderForAvdoede(avdoede)
+                .groupBy(TrygdetidPartial::behandlingId)
+                .values
+
+        return trygdetiderByBehandlingId
+            .filter { it.trygdetiderGjelderEksaktSammeAvdoede(avdoede) }
+            .sortedByDescending { trygdetider -> trygdetider.maxOfOrNull { it.opprettet } }
+            .map { it.first().behandlingId }
+    }
+
+    private fun behandlingStatusOkForKopieringAvTrygdetid(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean =
+        runBlocking {
+            behandlingKlient.hentBehandling(behandlingId, brukerTokenInfo).status in
+                listOf(
+                    IVERKSATT,
+                    BEREGNET,
+                    AVKORTET,
+                    FATTET_VEDTAK,
+                    ATTESTERT,
+                    TIL_SAMORDNING,
+                    SAMORDNET,
+                )
+        }
+
+    private fun sjekkAtTrygdetideneGjelderSammeAvdoede(
+        trygdetiderMaal: List<Trygdetid>,
+        trygdetiderKilde: List<Trygdetid>,
+        behandlingIdMaal: UUID,
+        behandlingIdKilde: UUID,
+    ) {
+        krev(trygdetiderMaal.map { it.ident }.sorted() == trygdetiderKilde.map { it.ident }.sorted()) {
+            val feilmelding = "Trygdetidene gjelder forskjellige avdøde"
+            logger.error("$feilmelding. Se sikkerlogg for detaljer.")
+            sikkerlogger().error(
+                """
+                $feilmelding ved kopiering av trygdetidsgrunnlag 
+                fra $behandlingIdKilde til $behandlingIdMaal
+                Mål: ${trygdetiderKilde.joinToString { it.ident }}
+                Kilde: ${trygdetiderMaal.joinToString { it.ident }}
+                """.trimIndent(),
+            )
+            feilmelding
+        }
+    }
+
+    private fun lagredeTrygdetiderHarSammeAvdoede(
+        behandlingId: UUID,
+        avdoede: List<Folkeregisteridentifikator>,
+    ): Boolean {
+        val trygdetidIdenter = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).map { it.ident }
+        return (
+            trygdetidIdenter.size == avdoede.size &&
+                trygdetidIdenter.containsAll(avdoede.map { it.value })
+        )
+    }
+}
+
+class ManglerForrigeTrygdetidMaaReguleresManuelt :
+    UgyldigForespoerselException(
+        "MANGLER_TRYGDETID_FOR_REGULERING",
+        "Forrige behandling mangler trygdetid, og kan dermed ikke reguleres manuelt",
+    )
+
+class TrygdetidAlleredeOpprettetException :
+    IkkeTillattException("TRYGDETID_FINNES_ALLEREDE", "Det er opprettet trygdetid for behandlingen allerede")
+
+class TrygdetidMaaHaFoedselsdatoException(
+    behandlingId: UUID,
+) : IkkeTillattException(
+        "TRYGDETID_MANGLER_FOEDSELSDATO",
+        "Kan ikke lage trygdetid uten fødselsdato, behandling: $behandlingId",
+    )
+
+class IngenTrygdetidFunnetForAvdoede :
+    UgyldigForespoerselException(
+        code = "TRYGDETID_IKKE_FUNNET_AVDOEDE",
+        detail = "Ingen trygdetider er funnet for den / de avdøde",
+    )
+
+class TrygdetidManglerBeregning :
+    UgyldigForespoerselException(
+        code = "TRYGDETID_MANGLER_BEREGNING",
+        detail = "Oppgitt trygdetid er ikke gyldig fordi det mangler en beregning",
+    )
+
+class IngenFoedselsdatoForAvdoedFunnet(
+    trygdetidId: UUID,
+) : UgyldigForespoerselException(
+        code = "FOEDSELSDATO_FOR_AVDOED_IKKE_FUNNET",
+        detail = "Fant ikke fødselsdato for avdød",
+        meta =
+            mapOf(
+                "trygdetidId" to trygdetidId,
+            ),
+    )
+
+class IngenDoedsdatoForAvdoedFunnet(
+    trygdetidId: UUID,
+) : UgyldigForespoerselException(
+        code = "FOEDSELSDATO_FOR_AVDOED_IKKE_FUNNET",
+        detail = "Fant ikke dødsdato for avdød",
+        meta =
+            mapOf(
+                "trygdetidId" to trygdetidId,
+            ),
+    )
+
+class TrygdetidIkkeFunnetForBehandling :
+    UgyldigForespoerselException(
+        code = "TRYGDETID_IKKE_FUNNET_BEHANDLING",
+        detail = "Etterspurt trygdetid er ikke funnet for behandlingen",
+    )

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleService.kt
@@ -1,0 +1,39 @@
+package no.nav.etterlatte.trygdetid.avtale
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.libs.common.trygdetid.avtale.TrygdetidAvtale
+import no.nav.etterlatte.libs.common.trygdetid.avtale.TrygdetidAvtaleKriteria
+import java.util.UUID
+
+class AvtaleService(
+    private val avtaleRepository: AvtaleRepository,
+) {
+    private var avtaler: List<TrygdetidAvtale>
+    private var kriterier: List<TrygdetidAvtaleKriteria>
+
+    init {
+        avtaler = loadJson("/trygdetid_avtaler.json")
+        kriterier = loadJson("/trygdetid_avtale_kriterier.json")
+    }
+
+    fun hentAvtaler(): List<TrygdetidAvtale> = avtaler
+
+    fun hentAvtaleKriterier(): List<TrygdetidAvtaleKriteria> = kriterier
+
+    fun hentAvtaleForBehandling(id: UUID): Trygdeavtale? = avtaleRepository.hentAvtale(id)
+
+    fun lagreAvtale(trygdeavtale: Trygdeavtale) {
+        avtaleRepository.lagreAvtale(trygdeavtale)
+    }
+
+    fun opprettAvtale(trygdeavtale: Trygdeavtale) {
+        avtaleRepository.opprettAvtale(trygdeavtale)
+    }
+
+    private inline fun <reified T> loadJson(filename: String) =
+        this::class.java.getResource(filename)?.readText()?.let { json ->
+            objectMapper.readValue<List<T>>(json)
+        } ?: throw RuntimeException("Unable to load $filename")
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/BehandlingKlient.kt
@@ -1,0 +1,150 @@
+package no.nav.etterlatte.trygdetid.klienter
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.michaelbull.result.mapBoth
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
+import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.retry
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.route.BehandlingTilgangsSjekk
+import no.nav.etterlatte.libs.ktor.route.PersonTilgangsSjekk
+import no.nav.etterlatte.libs.ktor.route.Tilgangssjekker
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import no.nav.etterlatte.libs.ktor.token.Saksbehandler
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class BehandlingKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
+
+class BehandlingKlient(
+    config: Config,
+    httpClient: HttpClient,
+) : BehandlingTilgangsSjekk,
+    PersonTilgangsSjekk {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val tilgangssjekker = Tilgangssjekker(config, httpClient)
+
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+    private val clientId = config.getString("behandling.client.id")
+    private val resourceUrl = config.getString("behandling.resource.url")
+
+    override suspend fun harTilgangTilBehandling(
+        behandlingId: UUID,
+        skrivetilgang: Boolean,
+        bruker: Saksbehandler,
+    ): Boolean = tilgangssjekker.harTilgangTilBehandling(behandlingId, skrivetilgang, bruker)
+
+    override suspend fun harTilgangTilPerson(
+        foedselsnummer: Folkeregisteridentifikator,
+        skrivetilgang: Boolean,
+        bruker: Saksbehandler,
+    ): Boolean = tilgangssjekker.harTilgangTilPerson(foedselsnummer, skrivetilgang, bruker)
+
+    suspend fun kanOppdatereTrygdetid(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean {
+        logger.info("Sjekker om behandling med behandlingId=$behandlingId kan oppdatere trygdetid")
+        val resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/oppdaterTrygdetid")
+
+        return downstreamResourceClient
+            .get(resource, brukerTokenInfo)
+            .mapBoth(
+                success = { true },
+                failure = {
+                    logger.info("Behandling med id $behandlingId kan ikke oppdatere trygdetid")
+                    false
+                },
+            )
+    }
+
+    suspend fun hentSisteIverksatteBehandling(
+        sakId: SakId,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): SisteIverksatteBehandling {
+        logger.info("Henter seneste iverksatte behandling for sak med id $sakId")
+
+        val response =
+            downstreamResourceClient.get(
+                resource = Resource(clientId = clientId, url = "$resourceUrl/saker/${sakId.sakId}/behandlinger/sisteIverksatte"),
+                brukerTokenInfo = brukerTokenInfo,
+            )
+
+        return response.mapBoth(
+            success = { deserialize(it.response.toString()) },
+            failure = {
+                logger.error("Kunne ikke hente seneste iverksatte behandling for sak med id $sakId")
+                throw it
+            },
+        )
+    }
+
+    suspend fun settBehandlingStatusTrygdetidOppdatert(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Boolean {
+        logger.info("Committer trygdetid oppdatert på behandling med id $behandlingId")
+        val response =
+            downstreamResourceClient.post(
+                resource = Resource(clientId = clientId, url = "$resourceUrl/behandlinger/$behandlingId/oppdaterTrygdetid"),
+                brukerTokenInfo = brukerTokenInfo,
+                postBody = "{}",
+            )
+
+        return response.mapBoth(
+            success = { true },
+            failure = {
+                logger.info("Kunne ikke committe trygdetid oppdatert på behandling med id $behandlingId", it.cause)
+                false
+            },
+        )
+    }
+
+    suspend fun hentBehandling(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): DetaljertBehandling {
+        logger.info("Henter behandling med behandlingId=$behandlingId")
+
+        return retry<DetaljertBehandling> {
+            downstreamResourceClient
+                .get(
+                    resource =
+                        Resource(
+                            clientId = clientId,
+                            url = "$resourceUrl/behandlinger/$behandlingId",
+                        ),
+                    brukerTokenInfo = brukerTokenInfo,
+                ).mapBoth(
+                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
+                )
+        }.let {
+            when (it) {
+                is RetryResult.Success -> {
+                    it.content
+                }
+
+                is RetryResult.Failure -> {
+                    throw BehandlingKlientException(
+                        "Klarte ikke hente behandling med behandlingId=$behandlingId",
+                        it.samlaExceptions(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/GrunnlagKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/GrunnlagKlient.kt
@@ -1,0 +1,69 @@
+package no.nav.etterlatte.trygdetid.klienter
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.michaelbull.result.mapBoth
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.retry
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class GrunnlagKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)
+
+class GrunnlagKlient(
+    config: Config,
+    httpClient: HttpClient,
+) {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+
+    private val clientId = config.getString("behandling.client.id")
+    private val resourceUrl = config.getString("behandling.resource.url")
+
+    suspend fun hentGrunnlag(
+        behandlingId: UUID,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): Grunnlag {
+        logger.info("Henter grunnlag for behandling med id=$behandlingId")
+
+        return retry<Grunnlag> {
+            downstreamResourceClient
+                .get(
+                    resource =
+                        Resource(
+                            clientId = clientId,
+                            url = "$resourceUrl/api/grunnlag/behandling/$behandlingId",
+                        ),
+                    brukerTokenInfo = brukerTokenInfo,
+                ).mapBoth(
+                    success = { resource -> resource.response.let { objectMapper.readValue(it.toString()) } },
+                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
+                )
+        }.let {
+            when (it) {
+                is RetryResult.Success -> {
+                    it.content
+                }
+
+                is RetryResult.Failure -> {
+                    throw GrunnlagKlientException(
+                        "Klarte ikke hente grunnlag for behandling med id=$behandlingId",
+                        it.samlaExceptions(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/PesysKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/PesysKlient.kt
@@ -1,0 +1,131 @@
+package no.nav.etterlatte.trygdetid.klienter
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.michaelbull.result.mapBoth
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.maskerFnr
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import org.slf4j.LoggerFactory
+import java.time.LocalDate
+
+interface PesysKlient {
+    suspend fun hentTrygdetidsgrunnlag(
+        avdoedMedFnr: Pair<String, LocalDate>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon
+}
+
+data class TrygdetidsgrunnlagRequest(
+    val fnr: String,
+    val dato: LocalDate,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Trygdetidsgrunnlag(
+    val land: String? = null, // ISO 3166-1 alpha-3 code
+    val fomDato: LocalDate,
+    val tomDato: LocalDate,
+    val poengIInnAr: Boolean? = null,
+    val poengIUtAr: Boolean? = null,
+    val ikkeProRata: Boolean? = null,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class TrygdetidsgrunnlagListe(
+    val trygdetidsgrunnlagListe: List<Trygdetidsgrunnlag>,
+)
+
+data class SakIdTrygdetidsgrunnlagListePairResponse(
+    val sakId: SakId,
+    val trygdetidsgrunnlagListe: TrygdetidsgrunnlagListe,
+)
+
+data class TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon(
+    val trygdetidUfoeretrygdpensjon: SakIdTrygdetidsgrunnlagListePairResponse?,
+    val trygdetidAlderspensjon: SakIdTrygdetidsgrunnlagListePairResponse?,
+)
+
+class PesysKlientImpl(
+    config: Config,
+    httpClient: HttpClient,
+) : PesysKlient {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+
+    private val clientId = config.getString("pen.client.id")
+    private val resourceUrl = config.getString("pen.client.url")
+
+    override suspend fun hentTrygdetidsgrunnlag(
+        avdoedMedFnr: Pair<String, LocalDate>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon {
+        logger.info("Henter trygdetidsgrunnlag(uføre og AP) for  ${avdoedMedFnr.first.maskerFnr()} fra PEN")
+
+        val (trygdetidUfoerepensjon, trygdetidAlderspensjon) =
+            coroutineScope {
+                val ufoereTrygd = async { hentTrygdetidsgrunnlagListeForLopendeUforetrygd(avdoedMedFnr, brukerTokenInfo) }
+                val alderspensjon = async { hentTrygdetidslisteForLoependeAlderspensjon(avdoedMedFnr, brukerTokenInfo) }
+
+                awaitAll(ufoereTrygd, alderspensjon)
+            }
+
+        return TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon(trygdetidUfoerepensjon, trygdetidAlderspensjon)
+    }
+
+    private suspend fun hentTrygdetidsgrunnlagListeForLopendeUforetrygd(
+        avdoed: Pair<String, LocalDate>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): SakIdTrygdetidsgrunnlagListePairResponse? =
+        downstreamResourceClient
+            .post(
+                resource =
+                    Resource(
+                        clientId = clientId,
+                        url = "$resourceUrl/api/uforetrygd/grunnlag/trygdetidsgrunnlagListeForLopendeUforetrygd",
+                    ),
+                brukerTokenInfo = brukerTokenInfo,
+                postBody = TrygdetidsgrunnlagRequest(avdoed.first, avdoed.second),
+            ).mapBoth(
+                success = { resource ->
+                    resource.response?.let {
+                        objectMapper.readValue<SakIdTrygdetidsgrunnlagListePairResponse?>(resource.response.toString())
+                    }
+                },
+                failure = { errorResponse -> throw errorResponse },
+            )
+
+    private suspend fun hentTrygdetidslisteForLoependeAlderspensjon(
+        avdoed: Pair<String, LocalDate>,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): SakIdTrygdetidsgrunnlagListePairResponse? =
+        downstreamResourceClient
+            .post(
+                resource =
+                    Resource(
+                        clientId = clientId,
+                        url = "$resourceUrl/api/alderspensjon/grunnlag/trygdetidsgrunnlagListeForLopendeAlderspensjon",
+                    ),
+                brukerTokenInfo = brukerTokenInfo,
+                postBody = TrygdetidsgrunnlagRequest(avdoed.first, avdoed.second),
+            ).mapBoth(
+                success = { resource ->
+                    resource.response?.let {
+                        objectMapper.readValue<SakIdTrygdetidsgrunnlagListePairResponse?>(
+                            resource.response.toString(),
+                        )
+                    }
+                },
+                failure = { errorResponse -> throw errorResponse },
+            )
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/VedtaksvurderingBehandlingKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/VedtaksvurderingBehandlingKlient.kt
@@ -1,0 +1,63 @@
+package no.nav.etterlatte.trygdetid.klienter
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.michaelbull.result.mapBoth
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import no.nav.etterlatte.libs.common.RetryResult
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.retry
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+import org.slf4j.LoggerFactory
+
+class VedtaksvurderingBehandlingKlient(
+    config: Config,
+    httpClient: HttpClient,
+) : VedtaksvurderingKlient {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+
+    private val clientId = config.getString("behandling.client.id")
+    private val resourceUrl = config.getString("behandling.resource.url")
+
+    override suspend fun hentIverksatteVedtak(
+        sakId: SakId,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<VedtakSammendragDto> {
+        logger.info("Henter iverksatte vedtak for sak: $sakId fra etterlatte-behandling")
+
+        return retry<List<VedtakSammendragDto>> {
+            downstreamResourceClient
+                .get(
+                    resource =
+                        Resource(
+                            clientId = clientId,
+                            url = "$resourceUrl/api/vedtak/sak/${sakId.sakId}/iverksatte",
+                        ),
+                    brukerTokenInfo = brukerTokenInfo,
+                ).mapBoth(
+                    success = { resource -> objectMapper.readValue(resource.response.toString()) },
+                    failure = { throwableErrorMessage -> throw throwableErrorMessage },
+                )
+        }.let {
+            when (it) {
+                is RetryResult.Success -> {
+                    it.content
+                }
+
+                is RetryResult.Failure -> {
+                    throw VedtaksvurderingKlientException(
+                        "Klarte ikke hente iverksatte vedtak for sak: $sakId fra etterlatte-behandling",
+                        it.samlaExceptions(),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/VedtaksvurderingKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/VedtaksvurderingKlient.kt
@@ -1,0 +1,17 @@
+package no.nav.etterlatte.trygdetid.klienter
+
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.ktor.token.BrukerTokenInfo
+
+interface VedtaksvurderingKlient {
+    suspend fun hentIverksatteVedtak(
+        sakId: SakId,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): List<VedtakSammendragDto>
+}
+
+class VedtaksvurderingKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/regler/BeregnTrygdetid.kt
@@ -1,0 +1,601 @@
+package no.nav.etterlatte.trygdetid.regler
+
+import no.nav.etterlatte.libs.common.IntBroek
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.FaktiskTrygdetid
+import no.nav.etterlatte.libs.common.trygdetid.FremtidigTrygdetid
+import no.nav.etterlatte.libs.common.trygdetid.justertForDager
+import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.Regel
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.RegelReferanse
+import no.nav.etterlatte.libs.regler.benytter
+import no.nav.etterlatte.libs.regler.definerKonstant
+import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
+import no.nav.etterlatte.libs.regler.med
+import no.nav.etterlatte.libs.regler.og
+import no.nav.etterlatte.trygdetid.TrygdetidGrunnlag
+import no.nav.etterlatte.trygdetid.TrygdetidType
+import no.nav.etterlatte.trygdetid.normaliser
+import java.time.LocalDate
+import java.time.Period
+import java.time.temporal.ChronoUnit
+import kotlin.math.roundToInt
+
+// Dato for når trygdetidsreglene begynte å gjelde er vilkårlig og bare satt langt tilbake
+val TRYGDETID_DATO: LocalDate = LocalDate.of(1900, 1, 1)
+
+data class TrygdetidPeriodeMedPoengaar(
+    val fra: LocalDate,
+    val til: LocalDate,
+    val poengInnAar: Boolean,
+    val poengUtAar: Boolean,
+)
+
+data class TrygdetidPeriodeGrunnlag(
+    val periode: FaktumNode<TrygdetidPeriodeMedPoengaar>,
+)
+
+data class TotalTrygdetidGrunnlag(
+    val beregnetTrygdetidPerioder: FaktumNode<List<Period>>,
+)
+
+/**
+ * Utility data class - brukes der vi trenger å samle nasjonal og teoretisk (generisk på faktisk eller fremtidig)
+ * fordi regel DSL klarer bare tre parameter per regel.
+ */
+data class TrygdetidPar<T>(
+    val nasjonal: T,
+    val teoretisk: T,
+)
+
+data class TrygdetidGrunnlagMedAvdoedGrunnlag(
+    val trygdetidGrunnlagListe: FaktumNode<List<TrygdetidGrunnlag>>,
+    val foedselsDato: FaktumNode<LocalDate>,
+    val doedsDato: FaktumNode<LocalDate>,
+    val norskPoengaar: FaktumNode<Int?>,
+    val yrkesskade: FaktumNode<Boolean>,
+    val nordiskKonvensjon: FaktumNode<Boolean>,
+)
+
+val nordiskKonvensjon: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Boolean> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Hent nordisk konvensjon",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::nordiskKonvensjon,
+        finnFelt = { it },
+    )
+
+val dagerPrMaanedTrygdetidGrunnlag =
+    definerKonstant<TrygdetidGrunnlagMedAvdoedGrunnlag, Int>(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "En måned trygdetid tilsvarer 30 dager",
+        regelReferanse = RegelReferanse("REGEL-TOTAL-TRYGDETID-DAGER-PR-MND-TRYGDETID"),
+        verdi = 30,
+    )
+
+val foedselsDato: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, LocalDate> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Hent fødselsdato",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::foedselsDato,
+        finnFelt = { it },
+    )
+
+val doedsDato: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, LocalDate> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Hent dødsdato",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::doedsDato,
+        finnFelt = { it },
+    )
+
+val antallPoengaarINorge: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Int?> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Finner antall poengår i Norge for overstyring av norske TT perioder",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::norskPoengaar,
+        finnFelt = { it },
+    )
+
+val erYrkesskade: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, Boolean> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Er dette yrkesskade",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::yrkesskade,
+        finnFelt = { it },
+    )
+
+val trygdetidGrunnlagListe: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, List<TrygdetidGrunnlag>> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Grunnlag liste med poengår",
+        finnFaktum = TrygdetidGrunnlagMedAvdoedGrunnlag::trygdetidGrunnlagListe,
+        finnFelt = { it },
+    )
+
+/**
+ * Sortere alle perioder ut ifra fra dato. Normalisering krever at listen er i datorekkefølge for å kunne finne
+ * forrige/neste period.
+ */
+val sortertTrygdetidGrunnlagListe =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Sortere grunnlag liste med poengår",
+        regelReferanse = RegelReferanse(id = "REGEL-SORTERE-TRYGDETIDSPERIODER"),
+    ) benytter trygdetidGrunnlagListe med {
+        it.sortedBy { x -> x.periode.fra }
+    }
+
+/**
+ * Tar periodene og justere for poeng inn år/ut år. Dvs endre inn år til 1.1. og ut år til 31.12. - med
+ * tilhørende flytting av forrige/neste til å unngå overlappende perioder.
+ */
+val normalisertTrygdetidGrunnlagListe =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Normaliser grunnlag liste ift poengår",
+        regelReferanse = RegelReferanse(id = "REGEL-NORMALISER-TRYGDETIDSPERIODER"),
+    ) benytter sortertTrygdetidGrunnlagListe med {
+        it.normaliser()
+    }
+
+/**
+ * Finn alle perioder som går mot faktisk nasjonal (norsk).
+ */
+val trygdetidGrunnlagListeFaktiskNorge =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Henter ut perioder med faktisk trygdetid i Norge",
+        regelReferanse = RegelReferanse(id = "REGEL-FINN-FAKTISK-NASJONAL-TRYGDETIDSPERIODER"),
+    ) benytter normalisertTrygdetidGrunnlagListe med { trygdetidPerioder ->
+        trygdetidPerioder.filter { it.erNasjonal() && it.type == TrygdetidType.FAKTISK }
+    }
+
+/**
+ * Finn alle perioder som går mot faktisk teoretisk (norsk og de som er merkert for prorata).
+ */
+val trygdetidGrunnlagListeFaktiskNorgeOgProrata =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Henter ut Norge og prorataperioder for teoretisk trygdetid",
+        regelReferanse =
+            RegelReferanse(
+                id = "REGEL-FINN-FAKTISK-NASJONAL-OG-PRORATA-TRYGDETIDSPERIODER",
+                versjon = "2",
+            ),
+    ) benytter normalisertTrygdetidGrunnlagListe med { trygdetidPerioder ->
+        trygdetidPerioder.filter { (it.erNasjonal() || it.prorata) && it.type == TrygdetidType.FAKTISK }
+    }
+
+/**
+ * Finn første fremtidig trygdetid (skal være enten ingen eller bare en) og juster det mtp antall dager i en måned.
+ *
+ * Framtidig trydetid regnes alltid i hele måneder, og skal gjelde fra og med hele måneden fra dødsdato. Det er ikke
+ * nødvendigvis slik i grunnlaget, så vi justerer opp perioden for framtidig trygdetid.
+ */
+val fremtidigTrygdetid =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Henter ut periode for fremtidig trygdetid",
+        regelReferanse = RegelReferanse(id = "REGEL-FINN-FREMTIDIG-TRYGDETIDSPERIODE", versjon = "1.2"),
+    ) benytter normalisertTrygdetidGrunnlagListe og dagerPrMaanedTrygdetidGrunnlag med {
+        trygdetidPerioder,
+        dagerPrMaaned,
+        ->
+        trygdetidPerioder.firstOrNull { it.type == TrygdetidType.FREMTIDIG }.let {
+            listOfNotNull(it).summer(dagerPrMaaned).justertForDager()
+        }
+    }
+
+/**
+ * Finn første dato for fremtidig trygdetid
+ */
+val fremtidigTrygdetidFra =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Henter ut periode for fremtidig trygdetid",
+        regelReferanse = RegelReferanse(id = "REGEL-FINN-START-FREMTIDIG-TRYGDETIDSPERIODE", versjon = "1.1"),
+    ) benytter normalisertTrygdetidGrunnlagListe med { trygdetidPerioder ->
+        trygdetidPerioder.singleOrNull { it.type == TrygdetidType.FREMTIDIG }?.periode?.fra
+    }
+
+/**
+ * Opptjeningstid er fra 16 år frem til siste dag i den måned som er før dødsfall. Input er fødselsdato og dødsdato.
+ * Hvis fremtidig trygdetid er satt, skal opptjeningstid beregnes frem til fremtidig trygdetid
+ */
+val finnDatoerForOpptjeningstid =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Konverter foedselsdato og doedsdato eller start fremtidig trygdetid til opptjeningsdatoer",
+        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-OPPTJENINGSDATOER", versjon = "2.1"),
+    ) benytter foedselsDato og doedsDato og fremtidigTrygdetidFra med {
+        foedt,
+        doed,
+        fremtidigFra,
+        ->
+        val opptjeningTil =
+            if (fremtidigFra != null) {
+                fremtidigFra.withDayOfMonth(1).minusDays(1)
+            } else {
+                doed.withDayOfMonth(1).minusDays(1)
+            }
+        Pair(
+            foedt.plusYears(16),
+            opptjeningTil,
+        )
+    }
+
+/**
+ * Summer faktisk nasjonal trygdetid.
+ */
+val summerFaktiskNorge =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Summer alle perioder for faktisk norge",
+        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-FAKTISK-NASJONAL-TRYGDETID", versjon = "1.2"),
+    ) benytter trygdetidGrunnlagListeFaktiskNorge og dagerPrMaanedTrygdetidGrunnlag med {
+        trygdetidPerioder,
+        dagerPrMaaned,
+        ->
+        val summert = trygdetidPerioder.summer(dagerPrMaaned)
+
+        FaktiskTrygdetid(
+            periode = summert,
+            antallMaaneder = summert.toTotalMonths(),
+        )
+    }
+
+/**
+ * Finn ut faktisk norsk tid - enten summert eller fra overstyrt poengår.
+ */
+val faktiskNorge =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Velg mellom beregnet faktisk nasjonal og overstyrt poengår",
+        regelReferanse = RegelReferanse(id = "REGEL-FAKTISK-NASJONAL-TRYGDETID"),
+    ) benytter summerFaktiskNorge og antallPoengaarINorge med { faktiskNorge, norskPoengaar ->
+        if (norskPoengaar != null) {
+            FaktiskTrygdetid(Period.ofYears(norskPoengaar), norskPoengaar * 12L)
+        } else {
+            faktiskNorge
+        }
+    }
+
+/**
+ * Summer faktisk teoretisk trygdetid. Tar høyde for overstyrt poengår (som erstatter alle norske perioder).
+ */
+val summerFaktiskTeoretisk =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Summer alle perioder for faktisk teoretisk",
+        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-FAKTISK-TEORETISK-TRYGDETID", versjon = "2.2"),
+    ) benytter trygdetidGrunnlagListeFaktiskNorgeOgProrata og antallPoengaarINorge og dagerPrMaanedTrygdetidGrunnlag med {
+        trygdetidPerioder,
+        norskPoengaar,
+        dagerPrMaaned,
+        ->
+
+        val beregningsPerioder =
+            if (norskPoengaar != null) {
+                trygdetidPerioder.filter { !it.erNasjonal() }
+            } else {
+                trygdetidPerioder
+            }
+
+        val summert =
+            beregningsPerioder
+                .summer(dagerPrMaaned)
+                .plusYears(norskPoengaar?.toLong() ?: 0)
+
+        FaktiskTrygdetid(
+            periode = summert,
+            antallMaaneder = summert.toTotalMonths(),
+        )
+    }
+
+/**
+ * Beregn hvor langt opptjeningstid er mellom to datoer.
+ */
+val opptjeningsTidIMnd =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Finn ut opptjeningstid",
+        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-OPPTJENINGSPERIODE"),
+    ) benytter finnDatoerForOpptjeningstid med { datoer ->
+        maxOf(
+            0L,
+            ChronoUnit.MONTHS.between(datoer.first, datoer.second),
+        )
+    }
+
+/**
+ * Finne ut om valg av nordisk konvensjon art 9 skal overstyre bruk av 4/5 regel
+ */
+val nordiskEllerFireFemtedeler =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Gruppere fremtidig trygdetid",
+        regelReferanse = RegelReferanse(id = "REGEL-NORDISK-ELLER-FIREFEMTEDELER", versjon = "1.1"),
+    ) benytter faktiskNorge og opptjeningsTidIMnd og nordiskKonvensjon med {
+        faktisk,
+        opptjening,
+        nordisk,
+        ->
+        val mindreEnnFireFemtedelerAvOpptjeningstiden = (faktisk.antallMaaneder * 5) < opptjening * 4
+        mindreEnnFireFemtedelerAvOpptjeningstiden && !nordisk
+    }
+
+/**
+ * Beregn fremtidig nasjonal trygdetid justert etter opptjeningsregel om at verdi er mindre enn 4/5 opptjeningstid.
+ */
+val fremtidigTrygdetidForNasjonal =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Regn ut fremtidig trygdetid nasjonal",
+        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-FREMTIDIG-NASJONAL-TRYGDETID", versjon = "2.1"),
+    ) benytter nordiskEllerFireFemtedeler og fremtidigTrygdetid og opptjeningsTidIMnd med
+        { nordiskEllerFireFemtedeler, fremtidig, opptjening ->
+            if (fremtidig != Period.ZERO) {
+                val fremtidigPeriode =
+                    fremtidig.justertForOpptjeningstiden(opptjening, nordiskEllerFireFemtedeler)
+
+                FremtidigTrygdetid(
+                    periode = fremtidigPeriode,
+                    antallMaaneder = fremtidigPeriode.toTotalMonths(),
+                    opptjeningstidIMaaneder = opptjening,
+                    mindreEnnFireFemtedelerAvOpptjeningstiden = nordiskEllerFireFemtedeler,
+                )
+            } else {
+                null
+            }
+        }
+
+/**
+ * Beregn fremtidig teoretisk trygdetid justert etter opptjeningsregel om at verdi er mindre enn 4/5 opptjeningstid.
+ */
+val fremtidigTrygdetidForTeoretisk =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Regn ut fremtidig trygdetid teoretisk",
+        regelReferanse = RegelReferanse(id = "REGEL-BEREGN-FREMTIDIG-TEORETISK-TRYGDETID", versjon = "2.1"),
+    ) benytter summerFaktiskTeoretisk og fremtidigTrygdetid og opptjeningsTidIMnd med {
+        teoretisk,
+        fremtidig,
+        opptjening,
+        ->
+        if (fremtidig != Period.ZERO) {
+            val mindreEnnFireFemtedelerAvOpptjeningstiden = teoretisk.antallMaaneder * 5 < opptjening * 4
+
+            val fremtidigPeriode =
+                fremtidig.justertForOpptjeningstiden(opptjening, mindreEnnFireFemtedelerAvOpptjeningstiden)
+
+            FremtidigTrygdetid(
+                periode = fremtidigPeriode,
+                antallMaaneder = fremtidigPeriode.toTotalMonths(),
+                opptjeningstidIMaaneder = opptjening,
+                mindreEnnFireFemtedelerAvOpptjeningstiden = mindreEnnFireFemtedelerAvOpptjeningstiden,
+            )
+        } else {
+            null
+        }
+    }
+
+/**
+ * Samler faktisk trygdetid til et par for å gjøre DSL bruk (maks antall parameter) lettere.
+ */
+val beregnetFaktiskTrygdetid =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Gruppere faktisk trygdetid",
+        regelReferanse = RegelReferanse(id = "REGEL-FAKTISK-TRYGDETID"),
+    ) benytter faktiskNorge og summerFaktiskTeoretisk med {
+        nasjonal,
+        teoretisk,
+        ->
+        TrygdetidPar(nasjonal, teoretisk)
+    }
+
+/**
+ * Samler fremtidig trygdetid (kun norsk) til et par for å gjøre DSL bruk (maks antall parameter) lettere men bare
+ * hvis det ikke er overstyrt poengår. Hvis det er overstyrt så erstatter den alle norske perioder og det er tatt med
+ * i faktisk trygdetid allerede.
+ */
+val beregnetFremtidigTrygdetid =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Gruppere fremtidig trygdetid",
+        regelReferanse = RegelReferanse(id = "REGEL-FREMTIDIG-TRYGDETID", versjon = "1.1"),
+    ) benytter fremtidigTrygdetidForNasjonal og fremtidigTrygdetidForTeoretisk og antallPoengaarINorge med {
+        nasjonal,
+        teoretisk,
+        norskPoengaar,
+        ->
+        if (norskPoengaar == null) {
+            TrygdetidPar(nasjonal, teoretisk)
+        } else {
+            TrygdetidPar(null, null)
+        }
+    }
+
+/**
+ * Både nasjonal og teoretisk må avrundes til nærmest hele år. Mindre enn 6 måned rundes ned. Mer eller lik 6 måned
+ * rundes opp.
+ */
+val avrundetTrygdetid: Regel<TrygdetidGrunnlagMedAvdoedGrunnlag, TrygdetidPar<Int>> =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Avrunder trygdetid til nærmeste hele år basert på måneder og dager",
+        regelReferanse = RegelReferanse(id = "REGEL-TOTAL-TRYGDETID-AVRUNDING", versjon = "2.0"),
+    ) benytter beregnetFaktiskTrygdetid og
+        beregnetFremtidigTrygdetid og dagerPrMaanedTrygdetidGrunnlag med { faktisk, fremtidig, antallDager ->
+
+            val faktiskNasjonal =
+                if (fremtidig.nasjonal != null && fremtidig.nasjonal.periode != Period.ZERO) {
+                    faktisk.nasjonal.avrundet()
+                } else {
+                    faktisk.nasjonal
+                }
+            val faktiskTeoretisk =
+                if (fremtidig.teoretisk != null && fremtidig.teoretisk.periode != Period.ZERO) {
+                    faktisk.teoretisk.avrundet()
+                } else {
+                    faktisk.teoretisk
+                }
+            TrygdetidPar(
+                nasjonal =
+                    minOf(
+                        faktiskNasjonal.periode.plus(fremtidig.nasjonal.periodeEllerZero()).normalisertMedDager(antallDager).let {
+                            if (it.months >= 6) {
+                                it.years + 1
+                            } else {
+                                it.years
+                            }
+                        },
+                        40,
+                    ),
+                teoretisk =
+                    minOf(
+                        faktiskTeoretisk.periode.plus(fremtidig.teoretisk.periodeEllerZero()).normalisertMedDager(antallDager).let {
+                            if (it.months >= 6) {
+                                it.years + 1
+                            } else {
+                                it.years
+                            }
+                        },
+                        40,
+                    ),
+            )
+        }
+
+/**
+ * Lag proratabrøk. Ingen verdier kan overstige 480 måned (40 år).
+ * Brøk av 1/1 brukes ikke - hvis verdier er det samme - så har vi ingen brøk.
+ */
+val avrundetBroek =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Avrunder trygdetid broek basert på måneder - maks 40 år",
+        regelReferanse = RegelReferanse(id = "REGEL-AVRUNDET-PRORATA-BROEK", versjon = "2.1"),
+    ) benytter beregnetFaktiskTrygdetid med { faktisk ->
+        val nasjonalAvrundet = faktisk.nasjonal.avrundet()
+        val teoretiskAvrundet = faktisk.teoretisk.avrundet()
+
+        if (teoretiskAvrundet.antallMaaneder != 0L &&
+            nasjonalAvrundet.antallMaaneder != teoretiskAvrundet.antallMaaneder
+        ) {
+            IntBroek.fra(
+                Pair(
+                    minOf(nasjonalAvrundet.antallMaaneder.toInt(), 480),
+                    minOf(teoretiskAvrundet.antallMaaneder.toInt(), 480),
+                ),
+            )
+        } else {
+            null
+        }
+    }
+
+/**
+ * Utility regel - gruppere 2 verdier ned til 1 - pga maks 3 klausul i regel DSL
+ */
+val avrundetTrygdetidOgBroek =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Samle avrundet trygdetid og avrundet broek",
+        regelReferanse = RegelReferanse(id = "REGEL-TOTAL-TRYGDETID-OG-BROEK-AVRUNDING"),
+    ) benytter avrundetTrygdetid og avrundetBroek med { trygdetid, broek ->
+        Pair(trygdetid, broek)
+    }
+
+/**
+ * Beregn detaljert trygdetid
+ */
+val beregnDetaljertBeregnetTrygdetid =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Beregn detaljert trygdetid",
+        regelReferanse = RegelReferanse(id = "REGEL-TOTAL-DETALJERT-TRYGDETID", versjon = "1.1"),
+    ) benytter beregnetFaktiskTrygdetid og
+        beregnetFremtidigTrygdetid og avrundetTrygdetidOgBroek med { faktisk, fremtidig, avrundet ->
+
+            DetaljertBeregnetTrygdetidResultat(
+                faktiskTrygdetidNorge = faktisk.nasjonal.avrundet(),
+                faktiskTrygdetidTeoretisk = faktisk.teoretisk.avrundet(),
+                fremtidigTrygdetidNorge = fremtidig.nasjonal?.avrundet(),
+                fremtidigTrygdetidTeoretisk = fremtidig.teoretisk?.avrundet(),
+                samletTrygdetidNorge = avrundet.first.nasjonal,
+                samletTrygdetidTeoretisk = avrundet.first.teoretisk,
+                prorataBroek = avrundet.second,
+                overstyrt = false,
+                yrkesskade = false,
+                beregnetSamletTrygdetidNorge = null,
+            )
+        }
+
+/**
+ * Inngangspunkt til hele regeltreet.
+ * Etter beregning - tar høyde for at yrkesskade gir altid 40 år.
+ */
+val beregnDetaljertBeregnetTrygdetidMedYrkesskade =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Sjekk om detaljert beregnet trygdetid skal endres pga yrkesskade",
+        regelReferanse = RegelReferanse(id = "REGEL-TOTAL-DETALJERT-TRYGDETID-YS"),
+    ) benytter beregnDetaljertBeregnetTrygdetid og erYrkesskade med { trygdetid, erYrkesskade ->
+        when (erYrkesskade) {
+            false -> {
+                trygdetid
+            }
+
+            true -> {
+                trygdetid.copy(
+                    yrkesskade = true,
+                    beregnetSamletTrygdetidNorge = trygdetid.samletTrygdetidNorge,
+                    samletTrygdetidNorge = 40,
+                )
+            }
+        }
+    }
+
+// Utility functions - burde vaert regler men må kalles fra flere steder.
+// Subsumsjonsverdi for regler som kalle disse skal fortsatt være korrekt.
+
+/**
+ * Summer periodene fra alle trygdetid grunnlag i listen med riktig oppjustering av dager il slutt.
+ */
+private fun List<TrygdetidGrunnlag>.summer(antallDagerEnMaanedTrygdetid: Int) =
+    this
+        .map { Period.between(it.periode.fra, it.periode.til) }
+        .reduceOrNull { acc, period ->
+            acc.plus(period)
+        }?.let {
+            it.normalisertMedDager(antallDagerEnMaanedTrygdetid)
+        } ?: Period.ZERO
+
+/**
+ * Juster en periode mtp regel om redusering av fremtidig trygdetid for de som har ikke nok opptjeningstid.
+ */
+private fun Period.justertForOpptjeningstiden(
+    opptjening: Long,
+    mindreEnnFireFemtedelerAvOpptjeningstiden: Boolean,
+): Period =
+    if (mindreEnnFireFemtedelerAvOpptjeningstiden) {
+        val fullTrygdetidIMaaneder = Period.ofYears(40).toTotalMonths().toInt()
+        val fireFemtedelerAvOpptjeningIMaaneder = opptjening * 0.8
+        val justertOpptjeningstidMaaneder = (fullTrygdetidIMaaneder - fireFemtedelerAvOpptjeningIMaaneder).roundToInt()
+        val justertOpptjeningsperiode = Period.ofMonths(justertOpptjeningstidMaaneder).normalized()
+        justertOpptjeningsperiode
+    } else {
+        this
+    }
+
+fun Period.normalisertMedDager(antallDagerEnMaanedTrygdetid: Int): Period {
+    val ekstraMaaneder = this.days / antallDagerEnMaanedTrygdetid
+    val gjenvaerendeDager = this.days % antallDagerEnMaanedTrygdetid
+    return Period.of(this.years, this.months + ekstraMaaneder, gjenvaerendeDager).normalized()
+}
+
+/**
+ * Utility-funksjon for å kunne legge sammen framtidig trygdetid (hvis den fins) enklere
+ */
+fun FremtidigTrygdetid?.periodeEllerZero(): Period = this?.periode ?: Period.ZERO

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/regler/BeregnTrygdetidGrunnlag.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/regler/BeregnTrygdetidGrunnlag.kt
@@ -1,0 +1,43 @@
+package no.nav.etterlatte.trygdetid.regler
+
+import no.nav.etterlatte.libs.regler.Regel
+import no.nav.etterlatte.libs.regler.RegelMeta
+import no.nav.etterlatte.libs.regler.RegelReferanse
+import no.nav.etterlatte.libs.regler.benytter
+import no.nav.etterlatte.libs.regler.finnFaktumIGrunnlag
+import no.nav.etterlatte.libs.regler.med
+import java.time.Month
+import java.time.MonthDay
+import java.time.Period
+
+val periode: Regel<TrygdetidPeriodeGrunnlag, TrygdetidPeriodeMedPoengaar> =
+    finnFaktumIGrunnlag(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Finner trygdetidsperiode fra grunnlag",
+        finnFaktum = TrygdetidPeriodeGrunnlag::periode,
+        finnFelt = { it },
+    )
+
+val beregnTrygdetidForPeriode =
+    RegelMeta(
+        gjelderFra = TRYGDETID_DATO,
+        beskrivelse = "Beregner trygdetid fra og med periodeFra til og med periodeTil i år, måneder og dager",
+        regelReferanse = RegelReferanse(id = "REGEL-TRYGDETID-BEREGNE-PERIODE", versjon = "1.1"),
+    ) benytter periode med { periode ->
+
+        fun TrygdetidPeriodeMedPoengaar.poengJustertFra() =
+            if (poengInnAar) {
+                fra.with(MonthDay.of(Month.JANUARY, 1))
+            } else {
+                fra
+            }
+
+        fun TrygdetidPeriodeMedPoengaar.poengJustertTil() =
+            if (poengUtAar) {
+                til.with(MonthDay.of(Month.DECEMBER, 31))
+            } else {
+                til
+            }
+
+        Period.between(periode.poengJustertFra(), periode.poengJustertTil().plusDays(1))
+    }

--- a/apps/etterlatte-behandling/src/main/resources/trygdetid_avtale_kriterier.json
+++ b/apps/etterlatte-behandling/src/main/resources/trygdetid_avtale_kriterier.json
@@ -1,0 +1,37 @@
+[
+  {
+    "kode" : "IK_YRK_BO",
+    "beskrivelse" : "Ikke yrkesaktiv, 3 års botid",
+    "fraDato" : "1899-12-31"
+  },
+  {
+    "kode" : "IK_YRK_TRYGD",
+    "beskrivelse" : "Ikke yrkesaktiv, 1 års trygdetid",
+    "fraDato" : "1899-12-31"
+  },
+  {
+    "kode" : "OMF_BES_EKSP",
+    "beskrivelse" : "Omfattet av bestemmelsene i eksportavtale",
+    "fraDato" : "1899-12-31"
+  },
+  {
+    "kode" : "YRK_ARB",
+    "beskrivelse" : "Yrkesaktiv, 1 års arbeid",
+    "fraDato" : "1899-12-31"
+  },
+  {
+    "kode" : "YRK_MEDL",
+    "beskrivelse" : "Yrkesaktiv i Norge eller EØS, ett års medlemskap i Norge",
+    "fraDato" : "1899-12-31"
+  },
+  {
+    "kode" : "YRK_MEDL_ALT",
+    "beskrivelse" : "Yrkesaktiv i Norge eller EØS",
+    "fraDato" : "1899-12-31"
+  },
+  {
+    "kode" : "YRK_TRYGD",
+    "beskrivelse" : "Yrkesaktiv, 1 års trygdetid",
+    "fraDato" : "1899-12-31"
+  }
+]

--- a/apps/etterlatte-behandling/src/main/resources/trygdetid_avtaler.json
+++ b/apps/etterlatte-behandling/src/main/resources/trygdetid_avtaler.json
@@ -1,0 +1,398 @@
+[
+  {
+    "kode" : "AUS",
+    "beskrivelse" : "Australia",
+    "fraDato" : "1899-12-31",
+    "datoer" : []
+  },
+  {
+    "kode" : "AUT",
+    "beskrivelse" : "Østerrike",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "AUT1986",
+        "beskrivelse" : "01.06.1986",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "AUT1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "AUT1998",
+        "beskrivelse" : "01.06.1998",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "BIH",
+    "beskrivelse" : "Bosnia-Hercegovina",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "BIH1992",
+        "beskrivelse" : "01.03.1992",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "CAN",
+    "beskrivelse" : "Canada",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "CAN1987",
+        "beskrivelse" : "01.01.1987",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "CAN2014",
+        "beskrivelse" : "01.01.2014",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "CHE",
+    "beskrivelse" : "Sveits",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "CHE1980",
+        "beskrivelse" : "01.11.1980",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "CHE1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "CHE2002",
+        "beskrivelse" : "EØS 01.06.2002",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "CHL",
+    "beskrivelse" : "Chile",
+    "fraDato" : "1899-12-31",
+    "datoer" : []
+  },
+  {
+    "kode" : "EOS_NOR",
+    "beskrivelse" : "Eøs-Avtalen/Nordisk Konvensjon",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "EOS1994",
+        "beskrivelse" : "01.01.1994",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "EOS2004",
+        "beskrivelse" : "01.05.2004",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "EOS2007",
+        "beskrivelse" : "01.01.2007",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "EOS2010",
+        "beskrivelse" : "01.06.2012",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "EOS2014",
+        "beskrivelse" : "12.04.2014",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "FRA",
+    "beskrivelse" : "Frankrike",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "FRA1956",
+        "beskrivelse" : "01.07.1956",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "FRA1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "GBR",
+    "beskrivelse" : "Storbritannia",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "GBR1958",
+        "beskrivelse" : "01.04.1958",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "GBR1991",
+        "beskrivelse" : "01.04.1991",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "GBR1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "HRV",
+    "beskrivelse" : "Kroatia",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "HRV1991",
+        "beskrivelse" : "08.10.1991",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "HRV2014",
+        "beskrivelse" : "EØS 12.04.2014",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "IND",
+    "beskrivelse" : "India",
+    "fraDato" : "2015-01-01",
+    "datoer" : [
+      {
+        "kode" : "IND2015",
+        "beskrivelse" : "01.01.2015",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "ISR",
+    "beskrivelse" : "Israel",
+    "fraDato" : "1899-12-31",
+    "datoer" : []
+  },
+  {
+    "kode" : "ITA",
+    "beskrivelse" : "Italia",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "ITA1962",
+        "beskrivelse" : "01.02.1962",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "ITA1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "KONVENSJON_DSF",
+    "beskrivelse" : "KONVENSJON fra DSF",
+    "fraDato" : "1899-12-31",
+    "datoer" : []
+  },
+  {
+    "kode" : "KOR",
+    "beskrivelse" : "Sør-Korea",
+    "fraDato" : "2015-01-01",
+    "datoer" : []
+  },
+  {
+    "kode" : "LUX",
+    "beskrivelse" : "Luxembourg",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "LUX1992",
+        "beskrivelse" : "01.03.1992",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "LUX1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "LUX1998",
+        "beskrivelse" : "01.09.1998",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "MNE",
+    "beskrivelse" : "Montenegro",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "MNE2006",
+        "beskrivelse" : "03.06.2006",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "NLD",
+    "beskrivelse" : "Nederland",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "NLD1990",
+        "beskrivelse" : "01.10.1990",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "NLD1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "NLD1997",
+        "beskrivelse" : "01.04.1997",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "NOR_KONV",
+    "beskrivelse" : "Nordisk Konvensjon",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "NOR1956",
+        "beskrivelse" : "01.11.1956",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "NOR1956",
+        "beskrivelse" : "01.01.1982",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "NOR1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "NOR2004",
+        "beskrivelse" : "01.09.2004",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "PRT",
+    "beskrivelse" : "Portugal",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "PRT1981",
+        "beskrivelse" : "01.09.1981",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "PRT1994",
+        "beskrivelse" : "EØS 01.01.1994",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "QEB",
+    "beskrivelse" : "Quebec",
+    "fraDato" : "1899-12-31",
+    "datoer" : []
+  },
+  {
+    "kode" : "SRB",
+    "beskrivelse" : "Serbia",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "SRB2003",
+        "beskrivelse" : "29.05.2003",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "SVN",
+    "beskrivelse" : "Slovenia",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "SVN1991",
+        "beskrivelse" : "25.06.1991",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "TUR",
+    "beskrivelse" : "Tyrkia",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "TUR1981",
+        "beskrivelse" : "01.06.1981",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "USA",
+    "beskrivelse" : "USA",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "USA1968",
+        "beskrivelse" : "Noteveksling av 26.06.1968",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "USA1984",
+        "beskrivelse" : "01.07.1984",
+        "fraDato" : "1899-12-31"
+      },
+      {
+        "kode" : "USA2003",
+        "beskrivelse" : "01.09.2003",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  },
+  {
+    "kode" : "YUG",
+    "beskrivelse" : "Jugoslavia",
+    "fraDato" : "1899-12-31",
+    "datoer" : [
+      {
+        "kode" : "YUG1976",
+        "beskrivelse" : "01.08.1976",
+        "fraDato" : "1899-12-31"
+      }
+    ]
+  }
+]

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidBeregningServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidBeregningServiceTest.kt
@@ -1,0 +1,238 @@
+package no.nav.etterlatte.trygdetid
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.Period
+
+class TrygdetidBeregningServiceTest {
+    @Test
+    fun `skal gi 22 aar total trygdetid`() {
+        val now = LocalDate.now()
+
+        val trygdetidGrunnlag =
+            listOf(
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(10)),
+                    periode = TrygdetidPeriode(now.minusYears(22), now.minusYears(12)),
+                ),
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(10)),
+                    periode = TrygdetidPeriode(now.minusYears(12), now.minusYears(2)),
+                ),
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(2)),
+                    periode = TrygdetidPeriode(now.minusYears(2), now),
+                ),
+            )
+
+        val beregnetTrygdetid =
+            TrygdetidBeregningService.beregnTrygdetid(
+                trygdetidGrunnlag = trygdetidGrunnlag,
+                foedselsDato = now,
+                doedsDato = now,
+                norskPoengaar = null,
+                yrkesskade = false,
+                nordiskKonvensjon = false,
+            )
+        beregnetTrygdetid shouldNotBe null
+        with(beregnetTrygdetid!!) {
+            regelResultat shouldNotBe null
+            tidspunkt shouldNotBe null
+            resultat.samletTrygdetidNorge shouldBe 22
+        }
+    }
+
+    @Test
+    fun `kan beregne trygdetid for overstyrt yrkesskade med ingen perioder`() {
+        val beregnetTrygdetid =
+            TrygdetidBeregningService.beregnTrygdetid(
+                trygdetidGrunnlag = emptyList(),
+                foedselsDato = LocalDate.of(1970, 1, 1),
+                doedsDato = LocalDate.of(2020, 1, 1),
+                norskPoengaar = null,
+                yrkesskade = true,
+                nordiskKonvensjon = false,
+            )
+        beregnetTrygdetid shouldNotBe null
+        beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 40
+    }
+
+    @Test
+    fun `skal gi maksimalt 40 aar total trygdetid`() {
+        val now = LocalDate.now()
+
+        val trygdetidGrunnlag =
+            listOf(
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(30)),
+                    periode = TrygdetidPeriode(now.minusYears(60), now.minusYears(30)),
+                ),
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(30)),
+                    periode = TrygdetidPeriode(now.minusYears(30), now),
+                ),
+            )
+
+        val beregnetTrygdetid =
+            TrygdetidBeregningService.beregnTrygdetid(
+                trygdetidGrunnlag = trygdetidGrunnlag,
+                foedselsDato = now,
+                doedsDato = now,
+                norskPoengaar = null,
+                yrkesskade = false,
+                nordiskKonvensjon = false,
+            )
+
+        beregnetTrygdetid!!.resultat.samletTrygdetidNorge shouldBe 40
+    }
+
+    @Test
+    fun `skal avrunde til naermeste aar med total trygdetid`() {
+        val trygdetidGrunnlag =
+            listOf(
+                trygdetidGrunnlag(beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofMonths(2))),
+            )
+
+        val beregnetTrygdetid =
+            TrygdetidBeregningService.beregnTrygdetid(
+                trygdetidGrunnlag = trygdetidGrunnlag,
+                foedselsDato = LocalDate.now(),
+                doedsDato = LocalDate.now(),
+                norskPoengaar = null,
+                yrkesskade = false,
+                nordiskKonvensjon = false,
+            )
+
+        beregnetTrygdetid!!.resultat.samletTrygdetidNorge shouldBe 0
+    }
+
+    @Test
+    fun `skal gi 22 aar total trygdetid med overstyrt poengaar`() {
+        val now = LocalDate.now()
+
+        val trygdetidGrunnlag =
+            listOf(
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(10)),
+                    periode = TrygdetidPeriode(now.minusYears(22), now.minusYears(12)),
+                ),
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(10)),
+                    periode = TrygdetidPeriode(now.minusYears(12), now.minusYears(2)),
+                ),
+                trygdetidGrunnlag(
+                    beregnetTrygdetidGrunnlag = beregnetTrygdetidGrunnlag(Period.ofYears(2)),
+                    periode = TrygdetidPeriode(now.minusYears(2), now),
+                ),
+            )
+
+        val beregnetTrygdetid =
+            TrygdetidBeregningService.beregnTrygdetid(
+                trygdetidGrunnlag = trygdetidGrunnlag,
+                foedselsDato = now,
+                doedsDato = now,
+                norskPoengaar = 10,
+                yrkesskade = false,
+                nordiskKonvensjon = false,
+            )
+        beregnetTrygdetid shouldNotBe null
+        with(beregnetTrygdetid!!) {
+            regelResultat shouldNotBe null
+            tidspunkt shouldNotBe null
+            resultat.samletTrygdetidNorge shouldBe 10
+        }
+    }
+
+    @Test
+    fun `skal gi 10 aar total trygdetid med kun overstyrt poengaar`() {
+        val now = LocalDate.now()
+
+        val trygdetidGrunnlag = emptyList<TrygdetidGrunnlag>()
+
+        val beregnetTrygdetid =
+            TrygdetidBeregningService.beregnTrygdetid(
+                trygdetidGrunnlag = trygdetidGrunnlag,
+                foedselsDato = now,
+                doedsDato = now,
+                norskPoengaar = 10,
+                yrkesskade = false,
+                nordiskKonvensjon = false,
+            )
+        beregnetTrygdetid shouldNotBe null
+        with(beregnetTrygdetid!!) {
+            regelResultat shouldNotBe null
+            tidspunkt shouldNotBe null
+            resultat.samletTrygdetidNorge shouldBe 10
+        }
+    }
+
+    @Test
+    fun `trygdetidgrunnlag skal gi tre aar, en maaned og tre dager trygdetid`() {
+        val trygdetidGrunnlag =
+            trygdetidGrunnlag(
+                periode = TrygdetidPeriode(fra = LocalDate.of(2020, 1, 1), til = LocalDate.of(2023, 2, 3)),
+            )
+
+        val beregnetTrygdetid = TrygdetidBeregningService.beregnTrygdetidGrunnlag(trygdetidGrunnlag)
+
+        beregnetTrygdetid shouldNotBe null
+        with(beregnetTrygdetid!!) {
+            regelResultat shouldNotBe null
+            tidspunkt shouldNotBe null
+            verdi shouldBe Period.of(3, 1, 3)
+        }
+    }
+
+    @Test
+    fun `trygdetidgrunnlag skal gi en dag trygdetid`() {
+        val trygdetidGrunnlag =
+            trygdetidGrunnlag(
+                periode = TrygdetidPeriode(fra = LocalDate.of(2023, 1, 1), til = LocalDate.of(2023, 1, 1)),
+            )
+
+        val beregnetTrygdetid = TrygdetidBeregningService.beregnTrygdetidGrunnlag(trygdetidGrunnlag)
+
+        beregnetTrygdetid shouldNotBe null
+        with(beregnetTrygdetid!!) {
+            regelResultat shouldNotBe null
+            tidspunkt shouldNotBe null
+            verdi shouldBe Period.ofDays(1)
+        }
+    }
+
+    @Test
+    fun `skal ikke vaere mulig aa opprette negativ periode i trygdetidgrunnlag`() {
+        assertThrows<UgyldigForespoerselException> {
+            trygdetidGrunnlag(
+                periode = TrygdetidPeriode(fra = LocalDate.of(2023, 1, 1), til = LocalDate.of(2022, 1, 1)),
+            )
+        }
+    }
+
+    @Test
+    fun `skal gi 40 aar total trygdetid for yrkesskade`() {
+        val now = LocalDate.now()
+
+        val trygdetidGrunnlag = emptyList<TrygdetidGrunnlag>()
+
+        val beregnetTrygdetid =
+            TrygdetidBeregningService.beregnTrygdetid(
+                trygdetidGrunnlag = trygdetidGrunnlag,
+                foedselsDato = now,
+                doedsDato = now,
+                norskPoengaar = 10,
+                yrkesskade = true,
+                nordiskKonvensjon = false,
+            )
+        beregnetTrygdetid shouldNotBe null
+        with(beregnetTrygdetid!!) {
+            regelResultat shouldNotBe null
+            tidspunkt shouldNotBe null
+            resultat.samletTrygdetidNorge shouldBe 40
+        }
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
@@ -1,0 +1,631 @@
+package no.nav.etterlatte.trygdetid
+
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.equals.shouldNotBeEqual
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.behandling.randomSakId
+import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.deserialize
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.grunnlag.Opplysning
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.tidspunkt.toNorskTid
+import no.nav.etterlatte.libs.common.toJson
+import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.GrunnlagOpplysningerDto
+import no.nav.etterlatte.libs.common.trygdetid.OpplysningerDifferanse
+import no.nav.etterlatte.libs.common.trygdetid.OpplysningsgrunnlagDto
+import no.nav.etterlatte.libs.common.trygdetid.UKJENT_AVDOED
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.kilde
+import no.nav.etterlatte.logger
+import no.nav.etterlatte.trygdetid.avtale.AvtaleService
+import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
+import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
+import no.nav.etterlatte.trygdetid.klienter.PesysKlient
+import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingKlient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.time.LocalDate
+import java.time.YearMonth
+import java.util.UUID
+import javax.sql.DataSource
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class TrygdetidServiceIntegrationTest(
+    dataSource: DataSource,
+) {
+    companion object {
+        @RegisterExtension
+        val dbExtension = DatabaseExtension()
+    }
+
+    private val saksbehandler = simpleSaksbehandler()
+
+    private val repository = TrygdetidRepository(dataSource)
+    private lateinit var trygdetidService: TrygdetidService
+
+    private val pdlKilde: Grunnlagsopplysning.Pdl = Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, "opplysningsId1")
+    private val regelKilde: Grunnlagsopplysning.RegelKilde = Grunnlagsopplysning.RegelKilde("regel", Tidspunkt.now(), "1")
+
+    private val grunnlagKlient: GrunnlagKlient = mockk<GrunnlagKlient>()
+
+    private val behandlingKlient = mockk<BehandlingKlient>()
+    private val avtaleService = mockk<AvtaleService>()
+    private val vedtaksvurderingKlient = mockk<VedtaksvurderingKlient>()
+
+    @BeforeAll
+    fun beforeAll() {
+        logger
+            .info(dbExtension.properties().toString())
+        trygdetidService =
+            TrygdetidServiceImpl(
+                repository,
+                behandlingKlient,
+                grunnlagKlient,
+                TrygdetidBeregningService,
+                mockk<PesysKlient>(),
+                avtaleService,
+                vedtaksvurderingKlient,
+                DummyFeatureToggleService(),
+            )
+    }
+
+    @AfterEach
+    fun afterEach() {
+        dbExtension.resetDb()
+    }
+
+    @Test
+    fun `skal hente trygdetid med differanse i opplysninger`() {
+        val behandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+
+        val nyDoedsdato =
+            grunnlagTestData.avdoede
+                .first()
+                .doedsdato!!
+                .plusDays(6)
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns grunnlagMedNyDoedsdato(nyDoedsdato)
+
+        repository.opprettTrygdetid(
+            trygdetid(
+                behandlingId = behandlingId,
+                sakId = randomSakId(),
+                opplysninger = opplysningsgrunnlag(grunnlagTestData),
+            ),
+        )
+
+        val trygdetider = runBlocking { trygdetidService.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+
+        val toLocalDate: (OpplysningsgrunnlagDto?) -> LocalDate? = { dto ->
+            dto?.let { deserialize<LocalDate>(it.opplysning.toJson()) }
+        }
+
+        with(trygdetider.firstOrNull()?.opplysningerDifferanse!!) {
+            differanse shouldBe true
+            with(oppdaterteGrunnlagsopplysninger) {
+                toLocalDate(avdoedFoedselsdato) shouldBe grunnlagTestData.avdoede.first().foedselsdato
+                toLocalDate(avdoedDoedsdato) shouldBe nyDoedsdato
+                toLocalDate(avdoedFylteSeksten) shouldBe
+                    grunnlagTestData.avdoede
+                        .first()
+                        .foedselsdato!!
+                        .plusYears(16)
+                toLocalDate(avdoedFyllerSeksti) shouldBe
+                    grunnlagTestData.avdoede
+                        .first()
+                        .foedselsdato!!
+                        .plusYears(66)
+            }
+        }
+    }
+
+    @Test
+    fun `skal opprette ny trygdetid og overskrive eksisterende`() {
+        val behandlingId = UUID.randomUUID()
+        val sakId = randomSakId()
+        val grunnlagTestData = GrunnlagTestData()
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
+                every { tidligereFamiliepleier } returns null
+            }
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlagTestData.hentOpplysningsgrunnlag()
+
+        val trygdetidOpprinnelig =
+            repository.opprettTrygdetid(
+                trygdetid(
+                    behandlingId = behandlingId,
+                    sakId = sakId,
+                    opplysninger = opplysningsgrunnlag(grunnlagTestData),
+                ),
+            )
+
+        val trygdetidOverskrevet =
+            runBlocking {
+                trygdetidService.opprettTrygdetiderForBehandling(behandlingId, saksbehandler, overskriv = true)
+            }.first()
+
+        trygdetidOverskrevet shouldNotBe null
+        trygdetidOverskrevet.id shouldNotBeEqual trygdetidOpprinnelig.id
+    }
+
+    @Test
+    fun `skal hente trygdetid uten differanse i opplysninger`() {
+        val behandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns grunnlagTestData.hentOpplysningsgrunnlag()
+
+        repository.opprettTrygdetid(
+            trygdetid(
+                behandlingId = behandlingId,
+                sakId = randomSakId(),
+                opplysninger = opplysningsgrunnlag(grunnlagTestData),
+            ),
+        )
+
+        val trygdetider = runBlocking { trygdetidService.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+
+        val toLocalDate: (OpplysningsgrunnlagDto?) -> LocalDate? = { dto ->
+            dto?.let { deserialize<LocalDate>(it.opplysning.toJson()) }
+        }
+        with(trygdetider.firstOrNull()?.opplysningerDifferanse!!) {
+            differanse shouldBe false
+            with(oppdaterteGrunnlagsopplysninger) {
+                toLocalDate(avdoedFoedselsdato) shouldBe grunnlagTestData.avdoede.first().foedselsdato
+                toLocalDate(avdoedDoedsdato) shouldBe grunnlagTestData.avdoede.first().doedsdato
+                toLocalDate(avdoedFylteSeksten) shouldBe
+                    grunnlagTestData.avdoede
+                        .first()
+                        .foedselsdato!!
+                        .plusYears(16)
+                toLocalDate(avdoedFyllerSeksti) shouldBe
+                    grunnlagTestData.avdoede
+                        .first()
+                        .foedselsdato!!
+                        .plusYears(66)
+            }
+        }
+    }
+
+    @Test
+    fun `skal hente trygdetid uten opplysningsgrunnlag`() {
+        val behandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+        val standardOpplysningsgrunnlag = grunnlagTestData.hentOpplysningsgrunnlag()
+
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns
+            Grunnlag(
+                soeker = standardOpplysningsgrunnlag.soeker,
+                familie = emptyList(),
+                sak = standardOpplysningsgrunnlag.sak,
+                metadata = standardOpplysningsgrunnlag.metadata,
+            )
+        repository.opprettTrygdetid(
+            trygdetid(
+                behandlingId = behandlingId,
+                sakId = randomSakId(),
+                ident = UKJENT_AVDOED,
+                opplysninger = emptyList(),
+            ),
+        )
+
+        val trygdetider = runBlocking { trygdetidService.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+
+        with(trygdetider.first()) {
+            ident shouldBe UKJENT_AVDOED
+            opplysningerDifferanse!! shouldBeEqual OpplysningerDifferanse(false, GrunnlagOpplysningerDto.tomt())
+        }
+    }
+
+    @Test
+    fun `skal forkaste forrige behandlings trygdetid hvis den feilaktig setter UKJENT_AVDOED`() {
+        val sakId = randomSakId()
+        val forrigeBehandlingId = UUID.randomUUID()
+        val behandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+        val standardOpplysningsgrunnlag = grunnlagTestData.hentOpplysningsgrunnlag()
+
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns standardOpplysningsgrunnlag
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { tidligereFamiliepleier } returns null
+                every { revurderingsaarsak } returns Revurderingaarsak.AKTIVITETSPLIKT
+                every { prosesstype } returns Prosesstype.MANUELL
+            }
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler) } returns
+            listOf(
+                VedtakSammendragDto(
+                    id = "1",
+                    behandlingId = forrigeBehandlingId,
+                    vedtakType = VedtakType.INNVILGELSE,
+                    behandlendeSaksbehandler = null,
+                    datoFattet = Tidspunkt.now().toNorskTid(),
+                    attesterendeSaksbehandler = null,
+                    datoAttestert = Tidspunkt.now().toNorskTid(),
+                    virkningstidspunkt = YearMonth.of(2024, 5),
+                    opphoerFraOgMed = null,
+                    iverksettelsesTidspunkt = Tidspunkt.now(),
+                ),
+            )
+        every { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+
+        repository.opprettTrygdetid(
+            trygdetid(
+                behandlingId = forrigeBehandlingId,
+                sakId = sakId,
+                ident = UKJENT_AVDOED,
+                opplysninger = emptyList(),
+            ),
+        )
+
+        val trygdetider = runBlocking { trygdetidService.opprettTrygdetiderForBehandling(behandlingId, saksbehandler) }
+
+        with(trygdetider.single()) {
+            ident shouldNotBe UKJENT_AVDOED
+        }
+    }
+
+    @Test
+    fun `skal slette trygdetid hvis ident ikke lenger finnes i familie`() {
+        val behandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns grunnlagTestData.hentOpplysningsgrunnlag()
+
+        repository.opprettTrygdetid(
+            trygdetid(
+                behandlingId = behandlingId,
+                sakId = randomSakId(),
+                ident = "123",
+                opplysninger = opplysningsgrunnlag(grunnlagTestData),
+            ),
+        )
+
+        val trygdetider = runBlocking { trygdetidService.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+
+        trygdetider shouldBe emptyList()
+    }
+
+    @Test
+    fun `skal kopiere trygdetid fra annen behandling`() {
+        val behandlingId = UUID.randomUUID()
+        val kildeBehandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+
+        val opplysningsgrunnlag = grunnlagTestData.hentOpplysningsgrunnlag()
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns opplysningsgrunnlag
+
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+        every { avtaleService.hentAvtaleForBehandling(any()) } returns opprettTrygdeavtale(kildeBehandlingId)
+        justRun { avtaleService.opprettAvtale(any()) }
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns randomSakId()
+                every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
+                every { tidligereFamiliepleier } returns null
+                every { revurderingsaarsak } returns null
+                every { prosesstype } returns Prosesstype.MANUELL
+            }
+
+        repository.opprettTrygdetid(
+            trygdetid(
+                behandlingId = behandlingId,
+                sakId = randomSakId(),
+                trygdetidGrunnlag =
+                    listOf(
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(fra = LocalDate.of(2021, 1, 1), til = LocalDate.of(2021, 2, 20)),
+                        ),
+                    ),
+            ),
+        )
+
+        repository
+            .opprettTrygdetid(
+                trygdetid(
+                    behandlingId = kildeBehandlingId,
+                    sakId = randomSakId(),
+                    trygdetidGrunnlag =
+                        listOf(
+                            trygdetidGrunnlag(
+                                periode = TrygdetidPeriode(fra = LocalDate.of(2020, 5, 1), til = LocalDate.of(2020, 7, 1)),
+                            ),
+                        ),
+                    overstyrtNorskPoengaar = 22,
+                    yrkesskade = true,
+                ),
+            ).also { it.beregnetTrygdetid shouldBe null }
+
+        runBlocking { trygdetidService.kopierOgOverskrivTrygdetid(behandlingId, kildeBehandlingId, saksbehandler) }
+
+        val trygdetidList = runBlocking { trygdetidService.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+        trygdetidList.size shouldBe 1
+
+        val trygdetid = trygdetidList.first()
+        trygdetid.kopiertGrunnlagFraBehandling shouldBe kildeBehandlingId
+        with(trygdetid.trygdetidGrunnlag.sortedBy { it.periode.fra }) {
+            this[0].periode.fra shouldBe LocalDate.of(2020, 5, 1)
+            this[0].periode.til shouldBe LocalDate.of(2020, 7, 1)
+        }
+        trygdetid.beregnetTrygdetid shouldNotBe null
+        trygdetid.overstyrtNorskPoengaar shouldBe 22
+        trygdetid.yrkesskade shouldBe true
+
+        verify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(kildeBehandlingId)
+            avtaleService.opprettAvtale(any())
+        }
+    }
+
+    @Test
+    fun `skal kopiere uten reberegning av trygdetid fra annen behandling hvis vi har en automatisk prosesstype`() {
+        val behandlingId = UUID.randomUUID()
+        val kildeBehandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+
+        val opplysningsgrunnlag = grunnlagTestData.hentOpplysningsgrunnlag()
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns opplysningsgrunnlag
+
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+        every { avtaleService.hentAvtaleForBehandling(any()) } returns opprettTrygdeavtale(kildeBehandlingId)
+        justRun { avtaleService.opprettAvtale(any()) }
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns randomSakId()
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { tidligereFamiliepleier } returns null
+                every { revurderingsaarsak } returns Revurderingaarsak.REGULERING
+                every { prosesstype } returns Prosesstype.AUTOMATISK
+            }
+        val detaljertResultat =
+            DetaljertBeregnetTrygdetidResultat(
+                faktiskTrygdetidNorge = null,
+                faktiskTrygdetidTeoretisk = null,
+                fremtidigTrygdetidNorge = null,
+                fremtidigTrygdetidTeoretisk = null,
+                samletTrygdetidNorge = 40,
+                samletTrygdetidTeoretisk = 40,
+                prorataBroek = null,
+                overstyrt = false,
+                yrkesskade = false,
+                beregnetSamletTrygdetidNorge = null,
+                overstyrtBegrunnelse = null,
+            )
+        repository
+            .opprettTrygdetid(
+                trygdetid(
+                    behandlingId = kildeBehandlingId,
+                    sakId = randomSakId(),
+                    trygdetidGrunnlag = listOf(),
+                    overstyrtNorskPoengaar = null,
+                    yrkesskade = true,
+                    beregnetTrygdetid =
+                        DetaljertBeregnetTrygdetid(
+                            resultat = detaljertResultat,
+                            tidspunkt = Tidspunkt.now(),
+                            regelResultat = "".toJsonNode(),
+                        ),
+                ),
+            )
+
+        runBlocking { trygdetidService.kopierSisteTrygdetidberegninger(behandlingId, kildeBehandlingId, saksbehandler) }
+
+        val trygdetidList = runBlocking { trygdetidService.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+        trygdetidList.size shouldBe 1
+
+        val trygdetid = trygdetidList.first()
+        trygdetid.kopiertGrunnlagFraBehandling shouldBe kildeBehandlingId
+        trygdetid.beregnetTrygdetid shouldNotBe null
+        trygdetid.beregnetTrygdetid?.resultat shouldBe detaljertResultat
+    }
+
+    @Test
+    fun `skal kopiere uten reberegning av trygdetid fra annen behandling hvis trygdetid er overstyrt`() {
+        val behandlingId = UUID.randomUUID()
+        val kildeBehandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+
+        val opplysningsgrunnlag = grunnlagTestData.hentOpplysningsgrunnlag()
+        coEvery {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        } returns opplysningsgrunnlag
+
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+        every { avtaleService.hentAvtaleForBehandling(any()) } returns opprettTrygdeavtale(kildeBehandlingId)
+        justRun { avtaleService.opprettAvtale(any()) }
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns randomSakId()
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { tidligereFamiliepleier } returns null
+                every { revurderingsaarsak } returns Revurderingaarsak.ANNEN
+            }
+
+        val detaljertResultat =
+            DetaljertBeregnetTrygdetidResultat(
+                faktiskTrygdetidNorge = null,
+                faktiskTrygdetidTeoretisk = null,
+                fremtidigTrygdetidNorge = null,
+                fremtidigTrygdetidTeoretisk = null,
+                samletTrygdetidNorge = 40,
+                samletTrygdetidTeoretisk = 40,
+                prorataBroek = null,
+                overstyrt = true,
+                yrkesskade = false,
+                beregnetSamletTrygdetidNorge = null,
+                overstyrtBegrunnelse = "Overstyrt for moro skyld",
+            )
+        repository
+            .opprettTrygdetid(
+                trygdetid(
+                    behandlingId = kildeBehandlingId,
+                    sakId = randomSakId(),
+                    trygdetidGrunnlag = listOf(),
+                    overstyrtNorskPoengaar = null,
+                    yrkesskade = true,
+                    beregnetTrygdetid =
+                        DetaljertBeregnetTrygdetid(
+                            resultat = detaljertResultat,
+                            tidspunkt = Tidspunkt.now(),
+                            regelResultat = "".toJsonNode(),
+                        ),
+                ),
+            )
+
+        runBlocking { trygdetidService.kopierSisteTrygdetidberegninger(behandlingId, kildeBehandlingId, saksbehandler) }
+
+        val trygdetidList = runBlocking { trygdetidService.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+        trygdetidList.size shouldBe 1
+
+        val trygdetid = trygdetidList.first()
+        trygdetid.kopiertGrunnlagFraBehandling shouldBe kildeBehandlingId
+        trygdetid.beregnetTrygdetid shouldNotBe null
+        trygdetid.beregnetTrygdetid?.resultat shouldBe detaljertResultat
+    }
+
+    @Test
+    fun `skal oppdatere begrunnelse i trygdetid`() {
+        val behandlingId = UUID.randomUUID()
+        val grunnlagTestData = GrunnlagTestData()
+        val begrunnelseTekst = "En begrunnelse"
+
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlagTestData.hentOpplysningsgrunnlag()
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) } returns true
+
+        val opprettetTrygdetid =
+            repository.opprettTrygdetid(
+                trygdetid(
+                    behandlingId = behandlingId,
+                    sakId = randomSakId(),
+                    opplysninger = opplysningsgrunnlag(grunnlagTestData),
+                ),
+            )
+
+        val trygdetidMedBegrunnelse =
+            runBlocking {
+                trygdetidService.oppdaterTrygdetidMedBegrunnelse(
+                    trygdetidId = opprettetTrygdetid.id,
+                    behandlingId = behandlingId,
+                    begrunnelse = begrunnelseTekst,
+                    brukerTokenInfo = saksbehandler,
+                )
+            }
+
+        trygdetidMedBegrunnelse.begrunnelse shouldBe begrunnelseTekst
+
+        val trygdetidMedSlettetBegrunnelse =
+            runBlocking {
+                trygdetidService.oppdaterTrygdetidMedBegrunnelse(
+                    trygdetidId = opprettetTrygdetid.id,
+                    behandlingId = behandlingId,
+                    begrunnelse = null,
+                    brukerTokenInfo = saksbehandler,
+                )
+            }
+
+        trygdetidMedSlettetBegrunnelse.begrunnelse shouldBe null
+    }
+
+    private fun opprettTrygdeavtale(behandlingId: UUID) =
+        Trygdeavtale(
+            behandlingId = behandlingId,
+            avtaleKode = "avtaleKode",
+            avtaleDatoKode = "avtaleDatoKode",
+            avtaleKriteriaKode = "avtaleKriteriaKode",
+            personKrets = null,
+            arbInntekt1G = null,
+            arbInntekt1GKommentar = "arbInntekt1GKommentar",
+            beregArt50 = null,
+            beregArt50Kommentar = "beregArt50Kommentar",
+            nordiskTrygdeAvtale = null,
+            nordiskTrygdeAvtaleKommentar = "nordiskTrygdeAvtaleKommentar",
+            kilde = Grunnlagsopplysning.Saksbehandler("ident", Tidspunkt.now()),
+        )
+
+    private fun opplysningsgrunnlag(grunnlagTestData: GrunnlagTestData): List<Opplysningsgrunnlag> {
+        val foedselsdato = grunnlagTestData.avdoede.first().foedselsdato!!
+        val doedsdato = grunnlagTestData.avdoede.first().doedsdato!!
+        val seksten =
+            grunnlagTestData.avdoede
+                .first()
+                .foedselsdato!!
+                .plusYears(16)
+        val sekstiseks =
+            grunnlagTestData.avdoede
+                .first()
+                .foedselsdato!!
+                .plusYears(66)
+        return listOf(
+            Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FOEDSELSDATO, pdlKilde, foedselsdato),
+            Opplysningsgrunnlag.ny(TrygdetidOpplysningType.DOEDSDATO, pdlKilde, doedsdato),
+            Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FYLT_16, regelKilde, seksten),
+            Opplysningsgrunnlag.ny(TrygdetidOpplysningType.FYLLER_66, regelKilde, sekstiseks),
+        )
+    }
+
+    private fun grunnlagMedNyDoedsdato(nyDoedsdato: LocalDate): Grunnlag {
+        val grunnlagTestData =
+            GrunnlagTestData(
+                opplysningsmapAvdoedOverrides =
+                    mapOf(Opplysningstype.DOEDSDATO to Opplysning.Konstant(UUID.randomUUID(), kilde, nyDoedsdato.toJsonNode())),
+            )
+        return grunnlagTestData.hentOpplysningsgrunnlag()
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -1,0 +1,2232 @@
+package no.nav.etterlatte.trygdetid
+
+import com.fasterxml.jackson.databind.JsonNode
+import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.Runs
+import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.verify
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.behandling.randomSakId
+import no.nav.etterlatte.funksjonsbrytere.DummyFeatureToggleService
+import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
+import no.nav.etterlatte.libs.common.behandling.BehandlingType
+import no.nav.etterlatte.libs.common.behandling.DetaljertBehandling
+import no.nav.etterlatte.libs.common.behandling.JaNei
+import no.nav.etterlatte.libs.common.behandling.Persongalleri
+import no.nav.etterlatte.libs.common.behandling.Prosesstype
+import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
+import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.SisteIverksatteBehandling
+import no.nav.etterlatte.libs.common.behandling.TidligereFamiliepleier
+import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
+import no.nav.etterlatte.libs.common.feilhaandtering.InternfeilException
+import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlag
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsdata
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.grunnlag.Opplysning
+import no.nav.etterlatte.libs.common.grunnlag.hentDoedsdato
+import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsdato
+import no.nav.etterlatte.libs.common.grunnlag.hentFoedselsnummer
+import no.nav.etterlatte.libs.common.grunnlag.opplysningstyper.Opplysningstype
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.person.Folkeregisteridentifikator
+import no.nav.etterlatte.libs.common.person.PersonRolle
+import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.toJsonNode
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.FaktiskTrygdetid
+import no.nav.etterlatte.libs.common.trygdetid.UKJENT_AVDOED
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import no.nav.etterlatte.libs.common.vedtak.VedtakSammendragDto
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED2_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.AVDOED_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.SOEKER_FOEDSELSNUMMER
+import no.nav.etterlatte.libs.testdata.grunnlag.eldreAvdoedTestopplysningerMap
+import no.nav.etterlatte.trygdetid.avtale.AvtaleService
+import no.nav.etterlatte.trygdetid.klienter.BehandlingKlient
+import no.nav.etterlatte.trygdetid.klienter.GrunnlagKlient
+import no.nav.etterlatte.trygdetid.klienter.PesysKlient
+import no.nav.etterlatte.trygdetid.klienter.TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon
+import no.nav.etterlatte.trygdetid.klienter.VedtaksvurderingKlient
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+import java.time.Period
+import java.util.UUID
+import java.util.UUID.randomUUID
+
+internal class TrygdetidServiceTest {
+    private val repository: TrygdetidRepository = mockk()
+    private val behandlingKlient: BehandlingKlient = mockk()
+    private val grunnlagKlient: GrunnlagKlient = mockk()
+    private val beregningService: TrygdetidBeregningService = spyk(TrygdetidBeregningService)
+    private val avtaleService = mockk<AvtaleService>()
+    private val pesysklient = mockk<PesysKlient>()
+    private val vedtaksvurderingKlient = mockk<VedtaksvurderingKlient>()
+    private val service: TrygdetidService =
+        TrygdetidServiceImpl(
+            repository,
+            behandlingKlient,
+            grunnlagKlient,
+            beregningService,
+            pesysklient,
+            avtaleService,
+            vedtaksvurderingKlient,
+            DummyFeatureToggleService(),
+        )
+
+    private fun trygdeavtale(behandlingId: UUID) =
+        Trygdeavtale(
+            id = randomUUID(),
+            behandlingId = behandlingId,
+            avtaleKode = "",
+            avtaleDatoKode = "",
+            avtaleKriteriaKode = "",
+            personKrets = JaNei.JA,
+            arbInntekt1G = JaNei.JA,
+            arbInntekt1GKommentar = "",
+            beregArt50 = JaNei.JA,
+            beregArt50Kommentar = "",
+            nordiskTrygdeAvtale = JaNei.JA,
+            nordiskTrygdeAvtaleKommentar = "",
+            kilde = Grunnlagsopplysning.automatiskSaksbehandler,
+        )
+
+    @BeforeEach
+    fun beforeEach() {
+        clearAllMocks()
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(any(), any()) } returns true
+        coEvery { pesysklient.hentTrygdetidsgrunnlag(any(), any()) } returns TrygdetidsgrunnlagUfoeretrygdOgAlderspensjon(null, null)
+    }
+
+    @AfterEach
+    fun afterEach() {
+        confirmVerified()
+    }
+
+    @Test
+    fun `skal hente trygdetid`() {
+        val behandlingId = randomUUID()
+
+        coEvery { repository.hentTrygdetiderForBehandling(any()) } returns listOf(trygdetid(behandlingId))
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+
+        val trygdetider = runBlocking { service.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+
+        trygdetider shouldNotBe null
+
+        verify(exactly = 1) {
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        }
+
+        coVerify(exactly = 2) {
+            grunnlagKlient.hentGrunnlag(any(), any())
+        }
+    }
+
+    @Test
+    fun `skal returnere null hvis trygdetid ikke finnes for behandling`() {
+        val behandlingId = randomUUID()
+        every { repository.hentTrygdetiderForBehandling(any()) } returns emptyList()
+
+        val trygdetider = runBlocking { service.hentTrygdetiderIBehandling(behandlingId, saksbehandler) }
+
+        trygdetider shouldBe emptyList()
+
+        verify(exactly = 1) { repository.hentTrygdetiderForBehandling(behandlingId) }
+    }
+
+    @Test
+    fun `skal opprette trygdetid`() {
+        val behandlingId = randomUUID()
+        val sakId = randomSakId()
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
+                every { tidligereFamiliepleier } returns null
+            }
+
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val forventetFoedselsdato =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsdato()!!
+                .verdi
+        val forventetDoedsdato =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentDoedsdato()!!
+                .verdi
+        val forventetIdent =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsnummer()!!
+                .verdi
+        val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        every { repository.hentTrygdetiderForBehandling(any()) } returns emptyList() andThen listOf(trygdetid)
+        every { repository.hentTrygdetid(any()) } returns trygdetid
+        every { repository.hentTrygdetidMedId(any(), any()) } returns trygdetid
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        every { repository.opprettTrygdetid(any()) } returns trygdetid
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+
+        runBlocking {
+            val opprettetTrygdetider = service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+
+            opprettetTrygdetider.first().trygdetidGrunnlag.size shouldBe 1
+            opprettetTrygdetider.first().trygdetidGrunnlag[0].type shouldBe TrygdetidType.FREMTIDIG
+
+            opprettetTrygdetider.first().beregnetTrygdetid?.resultat?.prorataBroek?.let {
+                it.nevner shouldNotBe 0
+            }
+        }
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+        coVerify {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 2) {
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.hentTrygdetidMedId(any(), any())
+            repository.opprettTrygdetid(
+                withArg { trygdetid ->
+                    trygdetid.opplysninger.let { opplysninger ->
+                        with(opplysninger[0]) {
+                            type shouldBe TrygdetidOpplysningType.FOEDSELSDATO
+                            opplysning shouldBe forventetFoedselsdato.toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[1]) {
+                            type shouldBe TrygdetidOpplysningType.FYLT_16
+                            opplysning shouldBe forventetFoedselsdato.plusYears(16).toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[2]) {
+                            type shouldBe TrygdetidOpplysningType.FYLLER_66
+                            opplysning shouldBe forventetFoedselsdato.plusYears(66).toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[3]) {
+                            type shouldBe TrygdetidOpplysningType.DOEDSDATO
+                            opplysning shouldBe forventetDoedsdato!!.toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                    }
+                },
+            )
+            repository.oppdaterTrygdetid(
+                withArg { trygdetid ->
+                    with(trygdetid.trygdetidGrunnlag[0]) {
+                        type shouldBe TrygdetidType.FREMTIDIG
+                    }
+                },
+            )
+            beregningService.beregnTrygdetidGrunnlag(any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+        verify {
+            behandling.id
+            behandling.sak
+            behandling.sakType
+            behandling.behandlingType
+            behandling.tidligereFamiliepleier
+        }
+    }
+
+    @Test
+    fun `skal kopiere trygdetid hvis revurdering`() {
+        val behandlingId = randomUUID()
+        val sakId = randomSakId()
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { revurderingsaarsak } returns Revurderingaarsak.DOEDSFALL
+            }
+
+        val forrigebehandlingId = randomUUID()
+        val forrigeTrygdetid = trygdetid(behandlingId, sakId)
+        val oppdatertTrygdetidCaptured = slot<Trygdetid>()
+        val vedtakSammendrag = mockVedtak(forrigebehandlingId, VedtakType.ENDRING)
+
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
+            SisteIverksatteBehandling(
+                forrigebehandlingId,
+            )
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns
+            listOf(
+                vedtakSammendrag,
+            )
+        every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(forrigeTrygdetid)
+        every { repository.opprettTrygdetid(capture(oppdatertTrygdetidCaptured)) } returns forrigeTrygdetid
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+        val avtale = trygdeavtale(forrigebehandlingId)
+        every { avtaleService.hentAvtaleForBehandling(forrigebehandlingId) } returns avtale
+        val avtaleSlot = slot<Trygdeavtale>()
+        every { avtaleService.opprettAvtale(capture(avtaleSlot)) } just Runs
+
+        runBlocking {
+            service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+        }
+
+        avtaleSlot.captured.shouldBeEqualToIgnoringFields(avtale, Trygdeavtale::behandlingId, Trygdeavtale::id)
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(forrigebehandlingId)
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+            avtaleService.hentAvtaleForBehandling(forrigebehandlingId)
+            avtaleService.opprettAvtale(any())
+
+            repository.opprettTrygdetid(oppdatertTrygdetidCaptured.captured)
+            with(oppdatertTrygdetidCaptured.captured) {
+                this.opplysninger.size shouldBe forrigeTrygdetid.opplysninger.size
+                for (i in 0 until this.opplysninger.size) {
+                    this.opplysninger[i].opplysning shouldBe forrigeTrygdetid.opplysninger[i].opplysning
+                    this.opplysninger[i].kilde shouldBe forrigeTrygdetid.opplysninger[i].kilde
+                    this.opplysninger[i].type shouldBe forrigeTrygdetid.opplysninger[i].type
+                }
+            }
+        }
+        coVerify {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+        }
+        verify {
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            behandling.behandlingType
+            behandling.sak
+            behandling.sakType
+            behandling.id
+            behandling.revurderingsaarsak
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
+        }
+    }
+
+    @Test
+    fun `skal kopiere trygdetid hvis revurdering med flyktningfordel`() {
+        val forrigeTrygdetid =
+            trygdetid(
+                behandlingId = randomUUID(),
+                sakId = randomSakId(),
+                ident = "UKJENT_AVDOED",
+                beregnetTrygdetid = beregnetTrygdetid(overstyrt = true, total = 39),
+            )
+        val behandlingId = randomUUID()
+        val sakId = forrigeTrygdetid.sakId
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.BARNEPENSJON
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { revurderingsaarsak } returns Revurderingaarsak.DOEDSFALL
+            }
+        val grunnlagUtenAvdoede = grunnlagUtenAvdoede()
+        val forrigebehandlingId = forrigeTrygdetid.behandlingId
+        val vedtakSammendrag = mockVedtak(forrigebehandlingId, VedtakType.ENDRING)
+
+        val oppdatertTrygdetidCaptured = slot<Trygdetid>()
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(forrigeTrygdetid)
+        every { repository.hentTrygdetidMedId(forrigebehandlingId, any()) } returns forrigeTrygdetid
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
+        every { repository.hentTrygdetiderForBehandling(forrigebehandlingId) } returns listOf(forrigeTrygdetid)
+        every { repository.opprettTrygdetid(capture(oppdatertTrygdetidCaptured)) } returns forrigeTrygdetid
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { grunnlagKlient.hentGrunnlag(behandlingId, any()) } returns grunnlagUtenAvdoede
+        coEvery { grunnlagKlient.hentGrunnlag(forrigebehandlingId, any()) } returns grunnlagUtenAvdoede
+        every { avtaleService.hentAvtaleForBehandling(forrigebehandlingId) } returns null
+
+        runBlocking {
+            service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+        }
+
+        coVerify {
+            grunnlagKlient.hentGrunnlag(any(), saksbehandler)
+        }
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(forrigebehandlingId)
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+            avtaleService.hentAvtaleForBehandling(forrigebehandlingId)
+
+            repository.opprettTrygdetid(oppdatertTrygdetidCaptured.captured)
+            with(oppdatertTrygdetidCaptured.captured) {
+                this.opplysninger.size shouldBe forrigeTrygdetid.opplysninger.size
+                for (i in 0 until this.opplysninger.size) {
+                    this.opplysninger[i].opplysning shouldBe forrigeTrygdetid.opplysninger[i].opplysning
+                    this.opplysninger[i].kilde shouldBe forrigeTrygdetid.opplysninger[i].kilde
+                    this.opplysninger[i].type shouldBe forrigeTrygdetid.opplysninger[i].type
+                }
+            }
+        }
+        verify {
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            behandling.id
+            behandling.sak
+            behandling.sakType
+            behandling.behandlingType
+            behandling.revurderingsaarsak
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
+        }
+    }
+
+    @Test
+    fun `skal opprette overstyrt trygdetid hvis det ikke finnes avdoede i grunnlag (ukjent avdoed)`() {
+        val behandlingId = randomUUID()
+        val grunnlagUtenAvdoede = grunnlagUtenAvdoede()
+        val behandling =
+            mockk<DetaljertBehandling> {
+                every { id } returns behandlingId
+                every { sak } returns randomSakId()
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { status } returns BehandlingStatus.VILKAARSVURDERT
+                every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
+                every { tidligereFamiliepleier } returns null
+            }
+
+        coEvery { grunnlagKlient.hentGrunnlag(behandlingId, any()) } returns grunnlagUtenAvdoede
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+
+        val opprettTrygdetidCaptured = slot<Trygdetid>()
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        every { repository.opprettTrygdetid(capture(opprettTrygdetidCaptured)) } returns mockk(relaxed = true)
+
+        runBlocking { service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler) }
+
+        opprettTrygdetidCaptured.captured.ident shouldBe UKJENT_AVDOED
+        opprettTrygdetidCaptured.captured.beregnetTrygdetid
+            ?.resultat
+            ?.overstyrt shouldBe true
+
+        coVerify {
+            grunnlagKlient.hentGrunnlag(any(), saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.opprettTrygdetid(any())
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+
+        verify {
+            behandling.id
+            behandling.behandlingType
+            behandling.status
+            behandling.sak
+            behandling.tidligereFamiliepleier
+        }
+    }
+
+    @Test
+    fun `skal opprette overstyrt trygdetid hvis det er en tidligere familiepleier sak`() {
+        val behandlingId = randomUUID()
+        val grunnlagUtenAvdoede = grunnlagUtenAvdoede()
+        val behandling =
+            mockk<DetaljertBehandling> {
+                every { id } returns behandlingId
+                every { sak } returns randomSakId()
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { status } returns BehandlingStatus.VILKAARSVURDERT
+                every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
+                every { soeker } returns SOEKER_FOEDSELSNUMMER.value
+                every { tidligereFamiliepleier?.svar } returns true
+            }
+
+        coEvery { grunnlagKlient.hentGrunnlag(behandlingId, any()) } returns grunnlagUtenAvdoede
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+
+        val opprettTrygdetidCaptured = slot<Trygdetid>()
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        every { repository.opprettTrygdetid(capture(opprettTrygdetidCaptured)) } returns mockk(relaxed = true)
+
+        runBlocking { service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler) }
+
+        opprettTrygdetidCaptured.captured.ident shouldBe SOEKER_FOEDSELSNUMMER.value
+        opprettTrygdetidCaptured.captured.beregnetTrygdetid
+            ?.resultat
+            ?.overstyrt shouldBe true
+
+        coVerify {
+            grunnlagKlient.hentGrunnlag(any(), saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.opprettTrygdetid(any())
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+
+        verify {
+            behandling.id
+            behandling.behandlingType
+            behandling.status
+            behandling.sak
+            behandling.tidligereFamiliepleier?.svar
+            behandling.soeker
+        }
+    }
+
+    @Test
+    fun `skal opprette trygdetid hvis revurdering og forrige trygdetid mangler og det ikke er regulering`() {
+        val behandlingId = randomUUID()
+        val sakId = randomSakId()
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { revurderingsaarsak } returns Revurderingaarsak.SOESKENJUSTERING
+            }
+        val forrigeBehandlingId = randomUUID()
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val forventetIdent =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsnummer()!!
+                .verdi
+        val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
+        val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
+        every { repository.hentTrygdetidMedId(any(), any()) } returns trygdetid
+        every { repository.opprettTrygdetid(any()) } returns trygdetid
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+
+        runBlocking {
+            service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 2) {
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
+            repository.hentTrygdetidMedId(any(), any())
+            repository.opprettTrygdetid(
+                withArg {
+                    it.trygdetidGrunnlag shouldBe emptyList()
+                },
+            )
+            repository.oppdaterTrygdetid(
+                withArg { trygdetid ->
+                    with(trygdetid.trygdetidGrunnlag[0]) {
+                        type shouldBe TrygdetidType.FREMTIDIG
+                    }
+                },
+            )
+            beregningService.beregnTrygdetidGrunnlag(any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+        verify {
+            behandling.revurderingsaarsak
+            behandling.id
+            behandling.sak
+            behandling.sakType
+            behandling.behandlingType
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
+        }
+    }
+
+    @Test
+    fun `skal ikke opprette trygdetid hvis revurdering og forrige trygdetid mangler og det er automatisk regulering`() {
+        val behandlingId = randomUUID()
+        val sakId = randomSakId()
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { revurderingsaarsak } returns Revurderingaarsak.REGULERING
+                every { prosesstype } returns Prosesstype.AUTOMATISK
+            }
+        val forrigeBehandlingId = randomUUID()
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
+
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+
+        runBlocking {
+            assertThrows<ManglerForrigeTrygdetidMaaReguleresManuelt> {
+                service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+            }
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
+        }
+        coVerify {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+        }
+        verify {
+            behandling.revurderingsaarsak
+            behandling.prosesstype
+            behandling.id
+            behandling.sak
+            behandling.behandlingType
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
+        }
+    }
+
+    @Test
+    fun `skal opprette trygdetid hvis revurdering og forrige trygdetid mangler og det er manuell regulering`() {
+        val behandlingId = randomUUID()
+        val sakId = randomSakId()
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.REVURDERING
+                every { revurderingsaarsak } returns Revurderingaarsak.REGULERING
+                every { prosesstype } returns Prosesstype.MANUELL
+            }
+        val forrigeBehandlingId = randomUUID()
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val forventetIdent =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsnummer()!!
+                .verdi
+        val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
+        val vedtakSammendrag = mockVedtak(forrigeBehandlingId, VedtakType.ENDRING)
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { behandlingKlient.hentSisteIverksatteBehandling(any(), any()) } returns
+            SisteIverksatteBehandling(
+                forrigeBehandlingId,
+            )
+        coEvery { vedtaksvurderingKlient.hentIverksatteVedtak(any(), any()) } returns listOf(vedtakSammendrag)
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns emptyList()
+        every { repository.opprettTrygdetid(any()) } returns trygdetid
+        every { repository.hentTrygdetidMedId(any(), any()) } returns trygdetid
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+
+        runBlocking {
+            service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 2) {
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            vedtaksvurderingKlient.hentIverksatteVedtak(sakId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            repository.hentTrygdetidMedId(any(), any())
+            repository.opprettTrygdetid(
+                withArg {
+                    it.trygdetidGrunnlag shouldBe emptyList()
+                },
+            )
+            repository.oppdaterTrygdetid(
+                withArg { trygdetid ->
+                    with(trygdetid.trygdetidGrunnlag[0]) {
+                        type shouldBe TrygdetidType.FREMTIDIG
+                    }
+                },
+            )
+            beregningService.beregnTrygdetidGrunnlag(any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+        verify {
+            behandling.revurderingsaarsak
+            behandling.prosesstype
+            behandling.id
+            behandling.sak
+            behandling.sakType
+            behandling.behandlingType
+            vedtakSammendrag.behandlingId
+            vedtakSammendrag.vedtakType
+        }
+    }
+
+    @Test
+    fun `skal feile ved opprettelse av trygdetid naar det allerede finnes for behandling`() {
+        val behandlingId = randomUUID()
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+
+        every { repository.hentTrygdetiderForBehandling(any()) } returns listOf(trygdetid(behandlingId))
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+
+        runBlocking {
+            assertThrows<TrygdetidAlleredeOpprettetException> {
+                service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+            }
+        }
+
+        coVerify {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 1) {
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+        }
+    }
+
+    @Test
+    fun `skal opprette manglende trygdetid ved opprettelse naar det allerede finnes men ikke for alle avdoede`() {
+        val behandlingId = randomUUID()
+        val sakId = randomSakId()
+
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
+                every { tidligereFamiliepleier } returns null
+            }
+
+        val doedsdato = LocalDate.of(2023, 11, 12)
+        val foedselsdato = doedsdato.minusYears(30)
+
+        val grunnlag = grunnlagMedEkstraAvdoedForelder(foedselsdato, doedsdato)
+
+        val trygdetid = trygdetid(behandlingId)
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        every { repository.hentTrygdetiderForBehandling(any()) } returns listOf(trygdetid)
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns
+            grunnlag
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        every { repository.opprettTrygdetid(any()) } returns trygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, any()) } returns trygdetid
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+
+        runBlocking {
+            service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.hentTrygdetidMedId(behandlingId, any())
+            repository.oppdaterTrygdetid(any())
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+
+            repository.opprettTrygdetid(
+                withArg { trygdetid ->
+                    trygdetid.ident shouldBe AVDOED2_FOEDSELSNUMMER.value
+                    trygdetid.sakId shouldBe sakId
+                    trygdetid.behandlingId shouldBe behandlingId
+
+                    trygdetid.opplysninger.let { opplysninger ->
+                        with(opplysninger[0]) {
+                            type shouldBe TrygdetidOpplysningType.FOEDSELSDATO
+                            opplysning shouldBe foedselsdato.toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[1]) {
+                            type shouldBe TrygdetidOpplysningType.FYLT_16
+                            opplysning shouldBe foedselsdato.plusYears(16).toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[2]) {
+                            type shouldBe TrygdetidOpplysningType.FYLLER_66
+                            opplysning shouldBe foedselsdato.plusYears(66).toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[3]) {
+                            type shouldBe TrygdetidOpplysningType.DOEDSDATO
+                            opplysning shouldBe doedsdato!!.toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                    }
+                },
+            )
+            beregningService.beregnTrygdetidGrunnlag(any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 2) {
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        verify {
+            behandling.id
+            behandling.sak
+            behandling.sakType
+            behandling.behandlingType
+            behandling.tidligereFamiliepleier
+        }
+    }
+
+    @Test
+    fun `skal feile ved opprettelse av trygdetid dersom behandling er i feil tilstand`() {
+        val behandlingId = randomUUID()
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(any(), any()) } returns false
+
+        runBlocking {
+            assertThrows<Exception> {
+                service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+            }
+        }
+
+        coVerify(exactly = 1) { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) }
+    }
+
+    @Test
+    fun `skal lagre nytt trygdetidsgrunnlag`() {
+        val behandlingId = randomUUID()
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val eksisterendeTrygdetid = trygdetid(behandlingId, ident = AVDOED_FOEDSELSNUMMER.value)
+
+        val grunnlag = mockk<Grunnlag>()
+        val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
+        every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
+        every { grunnlag.hentAvdoede() } returns listOf(avdoedGrunnlag)
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde =
+                    Grunnlagsopplysning.Pdl(
+                        tidspunktForInnhenting = Tidspunkt.now(),
+                        registersReferanse = null,
+                        opplysningId = null,
+                    ),
+                verdi = Folkeregisteridentifikator.of(AVDOED_FOEDSELSNUMMER.value).toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+
+        val trygdetid =
+            runBlocking {
+                service.lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandlingMedSjekk(
+                    behandlingId,
+                    eksisterendeTrygdetid.id,
+                    trygdetidGrunnlag,
+                    saksbehandler,
+                )
+            }
+
+        with(trygdetid.trygdetidGrunnlag.first()) {
+            beregnetTrygdetid?.verdi shouldBe Period.of(0, 1, 1)
+            beregnetTrygdetid?.regelResultat shouldNotBe null
+            beregnetTrygdetid?.tidspunkt shouldNotBe null
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            repository.hentTrygdetidMedId(behandlingId, trygdetid.id)
+            repository.oppdaterTrygdetid(
+                withArg {
+                    it.trygdetidGrunnlag.first().let { tg -> tg.id shouldBe trygdetidGrunnlag.id }
+                },
+            )
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+            beregningService.beregnTrygdetidGrunnlag(any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+    }
+
+    @Test
+    fun `skal lagre nytt trygdetidsgrunnlag med overstyrt poengaar`() {
+        val behandlingId = randomUUID()
+        val trygdetidGrunnlag =
+            trygdetidGrunnlag().copy(
+                periode = TrygdetidPeriode(LocalDate.now().minusYears(2), LocalDate.now().minusYears(1)),
+            )
+        val eksisterendeTrygdetid =
+            trygdetid(behandlingId, ident = AVDOED_FOEDSELSNUMMER.value).copy(overstyrtNorskPoengaar = 10)
+
+        val grunnlag = mockk<Grunnlag>()
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
+        every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+
+        val trygdetid =
+            runBlocking {
+                service.lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandlingMedSjekk(
+                    behandlingId,
+                    eksisterendeTrygdetid.id,
+                    trygdetidGrunnlag,
+                    saksbehandler,
+                )
+            }
+
+        with(trygdetid.trygdetidGrunnlag.first()) {
+            beregnetTrygdetid?.verdi shouldBe Period.of(1, 0, 1)
+            beregnetTrygdetid?.regelResultat shouldNotBe null
+            beregnetTrygdetid?.tidspunkt shouldNotBe null
+        }
+
+        trygdetid.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 10
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            repository.hentTrygdetidMedId(behandlingId, trygdetid.id)
+            repository.oppdaterTrygdetid(
+                withArg {
+                    it.trygdetidGrunnlag.first().let { tg -> tg.id shouldBe trygdetidGrunnlag.id }
+                },
+            )
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+            beregningService.beregnTrygdetidGrunnlag(any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `skal oppdatere trygdetidsgrunnlag`() {
+        val behandlingId = randomUUID()
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val eksisterendeTrygdetid =
+            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = AVDOED_FOEDSELSNUMMER.value)
+        val endretTrygdetidGrunnlag = trygdetidGrunnlag.copy(bosted = LandNormalisert.NORGE.isoCode)
+
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        val grunnlag = mockk<Grunnlag>()
+        val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
+        every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        every { grunnlag.hentAvdoede() } returns listOf(avdoedGrunnlag)
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde =
+                    Grunnlagsopplysning.Pdl(
+                        tidspunktForInnhenting = Tidspunkt.now(),
+                        registersReferanse = null,
+                        opplysningId = null,
+                    ),
+                verdi = Folkeregisteridentifikator.of(AVDOED_FOEDSELSNUMMER.value).toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+
+        val trygdetid =
+            runBlocking {
+                service.lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandlingMedSjekk(
+                    behandlingId,
+                    eksisterendeTrygdetid.id,
+                    endretTrygdetidGrunnlag,
+                    saksbehandler,
+                )
+            }
+
+        with(trygdetid.trygdetidGrunnlag.first()) {
+            beregnetTrygdetid?.verdi shouldBe Period.of(0, 1, 1)
+            beregnetTrygdetid?.regelResultat shouldNotBe null
+            beregnetTrygdetid?.tidspunkt shouldNotBe null
+        }
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id)
+            repository.oppdaterTrygdetid(
+                withArg {
+                    it.trygdetidGrunnlag.first().let { tg ->
+                        tg.id shouldBe trygdetidGrunnlag.id
+                        tg.bosted shouldBe LandNormalisert.NORGE.isoCode
+                    }
+                },
+            )
+            beregningService.beregnTrygdetidGrunnlag(any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+    }
+
+    @Test
+    fun `skal slette trygdetidsgrunnlag`() {
+        val behandlingId = randomUUID()
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val eksisterendeTrygdetid =
+            trygdetid(behandlingId, trygdetidGrunnlag = listOf(trygdetidGrunnlag), ident = AVDOED_FOEDSELSNUMMER.value)
+
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        val grunnlag = mockk<Grunnlag>()
+        val avdoedGrunnlag = mockk<Grunnlagsdata<JsonNode>>()
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
+        every { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        every { repository.hentTrygdetidMedId(behandlingId, eksisterendeTrygdetid.id) } returns eksisterendeTrygdetid
+        every { repository.oppdaterTrygdetid(any()) } answers { firstArg() }
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } answers { behandling(behandlingId = behandlingId) }
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        every { grunnlag.hentAvdoede() } returns listOf(avdoedGrunnlag)
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSDATO] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.FOEDSELSNUMMER] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde =
+                    Grunnlagsopplysning.Pdl(
+                        tidspunktForInnhenting = Tidspunkt.now(),
+                        registersReferanse = null,
+                        opplysningId = null,
+                    ),
+                verdi = Folkeregisteridentifikator.of(AVDOED_FOEDSELSNUMMER.value).toJsonNode(),
+            )
+        }
+        every { avdoedGrunnlag[Opplysningstype.DOEDSDATO] } answers {
+            Opplysning.Konstant(
+                id = randomUUID(),
+                kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                verdi = LocalDate.now().toJsonNode(),
+            )
+        }
+
+        val trygdetid =
+            runBlocking {
+                service.slettTrygdetidGrunnlagForTrygdetid(
+                    behandlingId,
+                    eksisterendeTrygdetid.id,
+                    trygdetidGrunnlag.id,
+                    saksbehandler,
+                )
+            }
+
+        trygdetid.trygdetidGrunnlag shouldNotContain trygdetidGrunnlag
+        trygdetid.beregnetTrygdetid shouldBe null
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            repository.hentTrygdetidMedId(behandlingId, trygdetid.id)
+            repository.oppdaterTrygdetid(
+                withArg {
+                    it.trygdetidGrunnlag shouldBe emptyList()
+                },
+            )
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+    }
+
+    @Test
+    fun `skal overstyre beregnet trygdetid og slette grunnlaget`() {
+        val behandlingId = randomUUID()
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val eksisterendeTrygdetid =
+            trygdetid(
+                behandlingId,
+                trygdetidGrunnlag = listOf(trygdetidGrunnlag),
+                ident = AVDOED_FOEDSELSNUMMER.value,
+                beregnetTrygdetid = beregnetTrygdetid(35, Tidspunkt.now()),
+            )
+        val oppdatertTrygdetidCaptured = slot<Trygdetid>()
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        coEvery { repository.hentTrygdetid(behandlingId) } returns eksisterendeTrygdetid
+        coEvery { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
+        coEvery {
+            repository.oppdaterTrygdetid(
+                capture(oppdatertTrygdetidCaptured),
+            )
+        } returns eksisterendeTrygdetid
+
+        service.overstyrBeregnetTrygdetidForAvdoed(
+            behandlingId,
+            eksisterendeTrygdetid.ident,
+            beregnetTrygdetid(25, Tidspunkt.now()).resultat,
+        )
+
+        coVerify(exactly = 1) {
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.oppdaterTrygdetid(oppdatertTrygdetidCaptured.captured)
+        }
+        with(oppdatertTrygdetidCaptured.captured) {
+            this.trygdetidGrunnlag.size shouldBe 0
+            this.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 25
+        }
+    }
+
+    @Test
+    fun `skal feile ved lagring av trygdetidsgrunnlag hvis behandling er i feil tilstand`() {
+        val behandlingId = randomUUID()
+        val trygdetidGrunnlag = trygdetidGrunnlag()
+        val eksisterendeTrygdetid = trygdetid(behandlingId)
+
+        coEvery { repository.hentTrygdetid(any()) } returns eksisterendeTrygdetid
+        coEvery { behandlingKlient.kanOppdatereTrygdetid(any(), any()) } returns false
+
+        runBlocking {
+            assertThrows<Exception> {
+                service.lagreTrygdetidGrunnlagForTrygdetidMedIdIBehandlingMedSjekk(
+                    behandlingId,
+                    eksisterendeTrygdetid.id,
+                    trygdetidGrunnlag,
+                    saksbehandler,
+                )
+            }
+        }
+
+        coVerify { behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler) }
+    }
+
+    @Test
+    fun `skal opprette ny trygdetid av kopi fra forrige behandling`() {
+        val sakId = randomSakId()
+        val behandlingId = randomUUID()
+        val forrigeBehandlingId = randomUUID()
+        val forrigeTrygdetidGrunnlag = trygdetidGrunnlag()
+        val forrigeTrygdetidOpplysninger = standardOpplysningsgrunnlag()
+        val forrigeTrygdetid =
+            trygdetid(
+                forrigeBehandlingId,
+                trygdetidGrunnlag = listOf(forrigeTrygdetidGrunnlag),
+                opplysninger = forrigeTrygdetidOpplysninger,
+                beregnetTrygdetid = beregnetTrygdetid(overstyrt = true, total = 20),
+            )
+
+        val regulering =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+            }
+
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns regulering
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns listOf(forrigeTrygdetid)
+        every { repository.opprettTrygdetid(any()) } answers { firstArg() }
+        every { avtaleService.hentAvtaleForBehandling(any()) } returns null
+
+        coEvery {
+            grunnlagKlient.hentGrunnlag(
+                forrigeBehandlingId,
+                saksbehandler,
+            )
+        } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+
+        runBlocking {
+            service.kopierSisteTrygdetidberegninger(behandlingId, forrigeBehandlingId, saksbehandler)
+        }
+
+        coVerify(exactly = 1) {
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+            repository.opprettTrygdetid(
+                match {
+                    it.behandlingId == behandlingId &&
+                        it.beregnetTrygdetid?.resultat?.overstyrt == true
+                },
+            )
+        }
+
+        coVerify(exactly = 2) {
+            grunnlagKlient.hentGrunnlag(forrigeBehandlingId, saksbehandler)
+        }
+
+        verify {
+            regulering.id
+            regulering.sak
+
+            avtaleService.hentAvtaleForBehandling(forrigeBehandlingId)
+        }
+    }
+
+    @Test
+    fun `skal opprette manglende trygdetid av kopi fra forrige behandling`() {
+        val sakId = randomSakId()
+        val behandlingId = randomUUID()
+        val forrigeBehandlingId = randomUUID()
+        val forrigeTrygdetidGrunnlag = trygdetidGrunnlag(begrunnelse = "Forrige")
+        val forrigeTrygdetidOpplysninger = standardOpplysningsgrunnlag()
+        val trygdetidGrunnlag = trygdetidGrunnlag(begrunnelse = "Eksisterende")
+        val trygdetidOpplysninger = standardOpplysningsgrunnlag()
+        val forrigeTrygdetid =
+            trygdetid(
+                forrigeBehandlingId,
+                trygdetidGrunnlag = listOf(forrigeTrygdetidGrunnlag),
+                opplysninger = forrigeTrygdetidOpplysninger,
+                ident = AVDOED2_FOEDSELSNUMMER.value,
+            )
+
+        val eksisterendeTrygdetid =
+            trygdetid(
+                behandlingId,
+                trygdetidGrunnlag = listOf(trygdetidGrunnlag),
+                opplysninger = trygdetidOpplysninger,
+            )
+
+        val revurdering =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { prosesstype } returns Prosesstype.MANUELL
+            }
+
+        val doedsdato = LocalDate.of(2023, 11, 12)
+        val foedselsdato = doedsdato.minusYears(30)
+
+        val nyligAvdoedFoedselsnummer = AVDOED2_FOEDSELSNUMMER
+        val nyligAvdoed: Grunnlagsdata<JsonNode> =
+            mapOf(
+                Opplysningstype.DOEDSDATO to konstantOpplysning(doedsdato),
+                Opplysningstype.PERSONROLLE to konstantOpplysning(PersonRolle.AVDOED),
+                Opplysningstype.FOEDSELSNUMMER to konstantOpplysning(nyligAvdoedFoedselsnummer),
+                Opplysningstype.FOEDSELSDATO to konstantOpplysning(foedselsdato),
+            )
+
+        coEvery { behandlingKlient.hentBehandling(behandlingId, saksbehandler) } returns revurdering
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler) } returns true
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
+        every { repository.hentTrygdetiderForBehandling(forrigeBehandlingId) } returns listOf(forrigeTrygdetid)
+        every { repository.opprettTrygdetid(any()) } answers { firstArg() }
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+        every { avtaleService.hentAvtaleForBehandling(any()) } returns null
+
+        coEvery {
+            grunnlagKlient.hentGrunnlag(
+                behandlingId,
+                saksbehandler,
+            )
+        } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+        coEvery { grunnlagKlient.hentGrunnlag(forrigeBehandlingId, saksbehandler) } returns
+            GrunnlagTestData(opplysningsmapAvdoedOverrides = nyligAvdoed).hentOpplysningsgrunnlag()
+
+        runBlocking {
+            val trygdetider = service.kopierSisteTrygdetidberegninger(behandlingId, forrigeBehandlingId, saksbehandler)
+
+            assertEquals(2, trygdetider.size)
+            assertTrue(trygdetider.any { it.ident == AVDOED_FOEDSELSNUMMER.value })
+            assertTrue(trygdetider.any { it.ident == AVDOED2_FOEDSELSNUMMER.value })
+        }
+
+        coVerify(exactly = 1) {
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.hentTrygdetiderForBehandling(forrigeBehandlingId)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            repository.opprettTrygdetid(match { it.behandlingId == behandlingId })
+        }
+        coVerify(exactly = 2) {
+            repository.oppdaterTrygdetid(any())
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+        }
+        coVerify(exactly = 2) {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+            grunnlagKlient.hentGrunnlag(forrigeBehandlingId, saksbehandler)
+        }
+        verify {
+            revurdering.id
+            revurdering.sak
+            revurdering.prosesstype
+
+            avtaleService.hentAvtaleForBehandling(forrigeBehandlingId)
+        }
+        verify(exactly = 2) {
+            avtaleService.hentAvtaleForBehandling(behandlingId)
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), any(), any())
+        }
+    }
+
+    @Test
+    fun `skal oppdater yrkesskade`() {
+        val behandlingId = randomUUID()
+
+        val behandling = behandling(behandlingId)
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val forventetIdent =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsnummer()!!
+                .verdi
+
+        val beregnetTrygdetid =
+            DetaljertBeregnetTrygdetid(
+                resultat =
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.ofYears(5),
+                                antallMaaneder = 5 * 12,
+                            ),
+                        faktiskTrygdetidTeoretisk = null,
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 5,
+                        samletTrygdetidTeoretisk = null,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                tidspunkt = Tidspunkt.now(),
+                regelResultat = "".toJsonNode(),
+            )
+
+        val eksisterendeTrygdetid =
+            trygdetid(
+                behandlingId,
+                beregnetTrygdetid = beregnetTrygdetid,
+                ident = forventetIdent.value,
+                trygdetidGrunnlag =
+                    listOf(
+                        TrygdetidGrunnlag(
+                            id = randomUUID(),
+                            type = TrygdetidType.FAKTISK,
+                            bosted = "",
+                            periode = TrygdetidPeriode(fra = LocalDate.now().minusYears(5), til = LocalDate.now()),
+                            kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                            beregnetTrygdetid =
+                                BeregnetTrygdetidGrunnlag(
+                                    verdi = Period.ofYears(5),
+                                    tidspunkt = Tidspunkt.now(),
+                                    regelResultat = "".toJsonNode(),
+                                ),
+                            begrunnelse = "",
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            prorata = false,
+                        ),
+                    ),
+            )
+
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { repository.hentTrygdetidMedId(any(), any()) } returns eksisterendeTrygdetid
+        coEvery { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+
+        val trygdetid =
+            runBlocking {
+                service.setYrkesskade(eksisterendeTrygdetid.id, behandlingId, true, saksbehandler)
+            }
+
+        trygdetid shouldNotBe null
+        trygdetid.yrkesskade shouldBe true
+        trygdetid.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 40
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(any(), any())
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any())
+        }
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+        verify(exactly = 1) {
+            repository.hentTrygdetidMedId(any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), any(), true, any())
+            repository.oppdaterTrygdetid(
+                withArg {
+                    it.yrkesskade shouldBe true
+                    it.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 40
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `skal oppdater overstyrt poengaar`() {
+        val behandlingId = randomUUID()
+
+        val behandling = behandling(behandlingId)
+        val grunnlag = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val forventetIdent =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsnummer()!!
+                .verdi
+
+        val beregnetTrygdetid =
+            DetaljertBeregnetTrygdetid(
+                resultat =
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.ofYears(5),
+                                antallMaaneder = 5 * 12,
+                            ),
+                        faktiskTrygdetidTeoretisk = null,
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 5,
+                        samletTrygdetidTeoretisk = null,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                tidspunkt = Tidspunkt.now(),
+                regelResultat = "".toJsonNode(),
+            )
+
+        val eksisterendeTrygdetid =
+            trygdetid(
+                behandlingId,
+                beregnetTrygdetid = beregnetTrygdetid,
+                ident = forventetIdent.value,
+                trygdetidGrunnlag =
+                    listOf(
+                        TrygdetidGrunnlag(
+                            id = randomUUID(),
+                            type = TrygdetidType.FAKTISK,
+                            bosted = "",
+                            periode = TrygdetidPeriode(fra = LocalDate.now().minusYears(5), til = LocalDate.now()),
+                            kilde = Grunnlagsopplysning.Saksbehandler("", Tidspunkt.now()),
+                            beregnetTrygdetid =
+                                BeregnetTrygdetidGrunnlag(
+                                    verdi = Period.ofYears(5),
+                                    tidspunkt = Tidspunkt.now(),
+                                    regelResultat = "".toJsonNode(),
+                                ),
+                            begrunnelse = "",
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            prorata = false,
+                        ),
+                    ),
+            )
+        coEvery { avtaleService.hentAvtaleForBehandling(any()) } returns null
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { repository.hentTrygdetidMedId(any(), any()) } returns eksisterendeTrygdetid
+        coEvery { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+
+        val trygdetid =
+            runBlocking {
+                service.overstyrNorskPoengaaarForTrygdetid(eksisterendeTrygdetid.id, behandlingId, 10, saksbehandler)
+            }
+
+        trygdetid shouldNotBe null
+        trygdetid.overstyrtNorskPoengaar shouldBe 10
+        trygdetid.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 10
+
+        coVerify(exactly = 1) {
+            avtaleService.hentAvtaleForBehandling(any())
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(any(), any())
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any())
+        }
+        verify(exactly = 1) {
+            repository.hentTrygdetidMedId(any(), any())
+            beregningService.beregnTrygdetid(any(), any(), any(), 10, any(), any())
+            repository.oppdaterTrygdetid(
+                withArg {
+                    it.overstyrtNorskPoengaar shouldBe 10
+                    it.beregnetTrygdetid?.resultat?.samletTrygdetidNorge shouldBe 10
+                },
+            )
+        }
+    }
+
+    @Test
+    fun `skal sjekke gyldighet og oppdatere status hvis behandlingstatus er VILKAARSVURDERT`() {
+        val behandlingId = randomUUID()
+        val eksisterendeTrygdetid = trygdetid(behandlingId, beregnetTrygdetid = beregnetTrygdetid())
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
+            behandling(behandlingId, behandlingStatus = BehandlingStatus.VILKAARSVURDERT)
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
+
+        runBlocking {
+            val oppdatert = service.sjekkGyldighetOgOppdaterBehandlingStatus(behandlingId, saksbehandler)
+            oppdatert shouldBe true
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(any(), any())
+            behandlingKlient.hentBehandling(any(), any())
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any())
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        }
+    }
+
+    @Test
+    fun `skal feile ved sjekking av gyldighet dersom det ikke finnes noe trygdetid`() {
+        val behandlingId = randomUUID()
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
+            behandling(behandlingId, behandlingStatus = BehandlingStatus.VILKAARSVURDERT)
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+
+        runBlocking {
+            assertThrows<IngenTrygdetidFunnetForAvdoede> {
+                service.sjekkGyldighetOgOppdaterBehandlingStatus(behandlingId, saksbehandler)
+            }
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(any(), any())
+            behandlingKlient.hentBehandling(any(), any())
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        }
+    }
+
+    @Test
+    fun `opprettOverstyrtBeregnetTrygdetid kaster feil hvis behandling ikke kan endres`() {
+        val behandlingId = randomUUID()
+        val behandling =
+            mockk<DetaljertBehandling> {
+                every { status } returns BehandlingStatus.IVERKSATT
+            }
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns behandling
+
+        assertThrows<IkkeTillattException> {
+            runBlocking { service.opprettOverstyrtBeregnetTrygdetid(behandlingId, true, saksbehandler) }
+        }
+        assertThrows<IkkeTillattException> {
+            runBlocking { service.opprettOverstyrtBeregnetTrygdetid(behandlingId, false, saksbehandler) }
+        }
+        coVerify(exactly = 2) {
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+        }
+        verify { behandling.status }
+    }
+
+    @Test
+    fun `opprettOverstyrtBeregnetTrygdetid kaster feil hvis ingen avdoede i persongalleri har doedsdato`() {
+        val sakId: SakId = randomSakId()
+        val behandlingId = randomUUID()
+        val grunnlag =
+            GrunnlagTestData(
+                opplysningsmapAvdoedOverrides =
+                    mapOf(
+                        Opplysningstype.DOEDSDATO to
+                            Opplysning.Konstant(
+                                randomUUID(),
+                                Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, null),
+                                objectMapper.valueToTree(null),
+                            ),
+                    ),
+                opplysningsmapSakOverrides =
+                    mapOf(
+                        Opplysningstype.PERSONGALLERI_V1 to
+                            Opplysning.Konstant(
+                                randomUUID(),
+                                Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, null),
+                                Persongalleri(
+                                    soeker = SOEKER_FOEDSELSNUMMER.value,
+                                    avdoed = listOf(AVDOED_FOEDSELSNUMMER.value),
+                                ).toJsonNode(),
+                            ),
+                    ),
+            ).hentOpplysningsgrunnlag()
+
+        val behandling: DetaljertBehandling =
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { status } returns BehandlingStatus.OPPRETTET
+            }
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns behandling
+        coEvery { grunnlagKlient.hentGrunnlag(behandlingId, any()) } returns grunnlag
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+
+        assertThrows<UgyldigForespoerselException> {
+            runBlocking {
+                service.opprettOverstyrtBeregnetTrygdetid(
+                    behandlingId,
+                    overskriv = false,
+                    saksbehandler,
+                )
+            }
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.hentBehandling(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), any())
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        }
+        verify {
+            behandling.status
+            behandling.id
+        }
+    }
+
+    @Test
+    fun `opprettOverstyrtBeregnetTrygdetid tillater aa opprette overstyrt trygdetid uten avdoede`() {
+        val sakId: SakId = randomSakId()
+        val behandlingId = randomUUID()
+        val grunnlag =
+            GrunnlagTestData(
+                opplysningsmapAvdoedOverrides = emptyMap(),
+                opplysningsmapSakOverrides =
+                    mapOf(
+                        Opplysningstype.PERSONGALLERI_V1 to
+                            Opplysning.Konstant(
+                                randomUUID(),
+                                Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, null),
+                                Persongalleri(
+                                    soeker = SOEKER_FOEDSELSNUMMER.value,
+                                    avdoed = emptyList(),
+                                ).toJsonNode(),
+                            ),
+                    ),
+            ).hentOpplysningsgrunnlag()
+
+        val opprettetTrygdetidSlot = slot<Trygdetid>()
+        val behandling: DetaljertBehandling =
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { status } returns BehandlingStatus.OPPRETTET
+                every { tidligereFamiliepleier } returns null
+            }
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns behandling
+        coEvery { grunnlagKlient.hentGrunnlag(behandlingId, any()) } returns grunnlag
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        every { repository.opprettTrygdetid(capture(opprettetTrygdetidSlot)) } returnsArgument 0
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+        runBlocking {
+            service.opprettOverstyrtBeregnetTrygdetid(
+                behandlingId,
+                overskriv = false,
+                saksbehandler,
+            )
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.hentBehandling(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), any())
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.opprettTrygdetid(any())
+        }
+        verify {
+            behandling.status
+            behandling.id
+            behandling.sak
+            behandling.tidligereFamiliepleier
+        }
+    }
+
+    @Test
+    fun `opprettOverstyrtBeregnetTrygdetid tillater å opprette overstyrt trygdetid uten avdøde med soeker som ident`() {
+        val sakId: SakId = randomSakId()
+        val behandlingId = randomUUID()
+        val grunnlag =
+            GrunnlagTestData(
+                opplysningsmapAvdoedOverrides = emptyMap(),
+                opplysningsmapSakOverrides =
+                    mapOf(
+                        Opplysningstype.PERSONGALLERI_V1 to
+                            Opplysning.Konstant(
+                                randomUUID(),
+                                Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, null),
+                                Persongalleri(
+                                    soeker = SOEKER_FOEDSELSNUMMER.value,
+                                    avdoed = emptyList(),
+                                ).toJsonNode(),
+                            ),
+                    ),
+            ).hentOpplysningsgrunnlag()
+
+        val opprettetTrygdetidSlot = slot<Trygdetid>()
+        val behandling: DetaljertBehandling =
+            mockk {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { status } returns BehandlingStatus.OPPRETTET
+                every { soeker } returns "12345678901"
+                every { tidligereFamiliepleier } returns
+                    TidligereFamiliepleier(
+                        svar = true,
+                        kilde = Grunnlagsopplysning.Saksbehandler("12345678901", Tidspunkt.now()),
+                        foedselsnummer = null,
+                        startPleieforhold = LocalDate.now().minusYears(1),
+                        opphoertPleieforhold = LocalDate.now(),
+                        begrunnelse = "Begrunnelse",
+                    )
+            }
+        coEvery { behandlingKlient.hentBehandling(behandlingId, any()) } returns behandling
+        coEvery { grunnlagKlient.hentGrunnlag(behandlingId, any()) } returns grunnlag
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns emptyList()
+        every { repository.opprettTrygdetid(capture(opprettetTrygdetidSlot)) } returnsArgument 0
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+        runBlocking {
+            service.opprettOverstyrtBeregnetTrygdetid(
+                behandlingId,
+                overskriv = false,
+                saksbehandler,
+            )
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.hentBehandling(any(), any())
+            grunnlagKlient.hentGrunnlag(any(), any())
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.opprettTrygdetid(any())
+        }
+        verify {
+            behandling.status
+            behandling.id
+            behandling.sak
+            behandling.soeker
+            behandling.tidligereFamiliepleier
+        }
+    }
+
+    @Test
+    fun `skal feile ved sjekking av gyldighet dersom det ikke finnes noe beregning i trygdetid`() {
+        val behandlingId = randomUUID()
+        val eksisterendeTrygdetid = trygdetid(behandlingId, beregnetTrygdetid = null)
+
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
+            behandling(behandlingId, behandlingStatus = BehandlingStatus.VILKAARSVURDERT)
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.hentTrygdetiderForBehandling(behandlingId) } returns listOf(eksisterendeTrygdetid)
+
+        runBlocking {
+            assertThrows<TrygdetidManglerBeregning> {
+                service.sjekkGyldighetOgOppdaterBehandlingStatus(behandlingId, saksbehandler)
+            }
+        }
+
+        coVerify(exactly = 1) {
+            behandlingKlient.kanOppdatereTrygdetid(any(), any())
+            behandlingKlient.hentBehandling(any(), any())
+            repository.hentTrygdetiderForBehandling(behandlingId)
+        }
+    }
+
+    @Test
+    fun `skal ikke opprette fremtidig grunnlag hvis man er for gammel`() {
+        val behandlingId = randomUUID()
+        val sakId = randomSakId()
+        val behandling =
+            mockk<DetaljertBehandling>().apply {
+                every { id } returns behandlingId
+                every { sak } returns sakId
+                every { sakType } returns SakType.OMSTILLINGSSTOENAD
+                every { behandlingType } returns BehandlingType.FØRSTEGANGSBEHANDLING
+                every { tidligereFamiliepleier } returns null
+            }
+        val grunnlag =
+            GrunnlagTestData(opplysningsmapAvdoedOverrides = eldreAvdoedTestopplysningerMap).hentOpplysningsgrunnlag()
+        val forventetFoedselsdato =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsdato()!!
+                .verdi
+        val forventetDoedsdato =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentDoedsdato()!!
+                .verdi
+        val forventetIdent =
+            grunnlag
+                .hentAvdoede()
+                .first()
+                .hentFoedselsnummer()!!
+                .verdi
+        val trygdetid = trygdetid(behandlingId, sakId, ident = forventetIdent.value)
+
+        every { repository.hentTrygdetiderForBehandling(any()) } returns emptyList() andThen listOf(trygdetid)
+        every { repository.hentTrygdetid(any()) } returns trygdetid
+        coEvery { behandlingKlient.hentBehandling(any(), any()) } returns behandling
+        coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlag
+        every { repository.opprettTrygdetid(any()) } returns trygdetid
+        coEvery { behandlingKlient.settBehandlingStatusTrygdetidOppdatert(any(), any()) } returns true
+        every { repository.oppdaterTrygdetid(any()) } returnsArgument 0
+
+        runBlocking {
+            val opprettetTrygdetid = service.opprettTrygdetiderForBehandling(behandlingId, saksbehandler)
+
+            opprettetTrygdetid.first().trygdetidGrunnlag.size shouldBe 0
+        }
+
+        coVerify(exactly = 1) {
+            grunnlagKlient.hentGrunnlag(behandlingId, saksbehandler)
+            behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+            behandlingKlient.hentBehandling(behandlingId, saksbehandler)
+            behandlingKlient.settBehandlingStatusTrygdetidOppdatert(behandlingId, saksbehandler)
+            repository.hentTrygdetiderForBehandling(behandlingId)
+            repository.opprettTrygdetid(
+                withArg { trygdetid ->
+                    trygdetid.opplysninger.let { opplysninger ->
+                        with(opplysninger[0]) {
+                            type shouldBe TrygdetidOpplysningType.FOEDSELSDATO
+                            opplysning shouldBe forventetFoedselsdato.toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[1]) {
+                            type shouldBe TrygdetidOpplysningType.FYLT_16
+                            opplysning shouldBe forventetFoedselsdato.plusYears(16).toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[2]) {
+                            type shouldBe TrygdetidOpplysningType.FYLLER_66
+                            opplysning shouldBe forventetFoedselsdato.plusYears(66).toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                        with(opplysninger[3]) {
+                            type shouldBe TrygdetidOpplysningType.DOEDSDATO
+                            opplysning shouldBe forventetDoedsdato!!.toJsonNode()
+                            kilde shouldNotBe null
+                        }
+                    }
+                },
+            )
+        }
+        verify {
+            behandling.id
+            behandling.sak
+            behandling.sakType
+            behandling.behandlingType
+            behandling.tidligereFamiliepleier
+        }
+    }
+
+    @Nested
+    inner class BehandlingMedSammeAvdoed {
+        private val grunnlagMock = mockk<Grunnlag>()
+        private lateinit var avdoedeMocks: List<Grunnlagsdata<JsonNode>>
+
+        private fun setupGrunnlagMock(avdoede: List<Folkeregisteridentifikator>) {
+            avdoedeMocks =
+                avdoede.map { avdoed ->
+                    mockk<Grunnlagsdata<JsonNode>> {
+                        every { get(Opplysningstype.FOEDSELSNUMMER) } answers { konstantOpplysning(avdoed) }
+                    }
+                }
+            coEvery { grunnlagKlient.hentGrunnlag(any(), any()) } returns grunnlagMock
+            every { grunnlagMock.hentAvdoede() } returns avdoedeMocks
+        }
+
+        private fun verifyHentetAvdoedeFraGrunnlag(behandlingId: UUID) {
+            coVerify(exactly = 1) {
+                grunnlagKlient.hentGrunnlag(behandlingId, any())
+                grunnlagMock.hentAvdoede()
+            }
+            avdoedeMocks.forEach {
+                verify(exactly = 1) {
+                    it[Opplysningstype.FOEDSELSNUMMER]
+                }
+            }
+        }
+
+        @Test
+        fun `finnBehandlingMedTrygdetidForSammeAvdoede skal finne behandling med ok status`() {
+            val annenBehandling = behandling(randomUUID(), randomSakId(), BehandlingStatus.BEREGNET)
+            val avdoed1 = Folkeregisteridentifikator.of("10418305857")
+            val avdoed2 = Folkeregisteridentifikator.of("01448203510")
+
+            setupGrunnlagMock(listOf(avdoed1, avdoed2))
+            val behandlingId = randomUUID()
+
+            every { repository.hentTrygdetiderForBehandling(behandlingId) } returns
+                listOf(
+                    trygdetid(behandlingId, ident = avdoed1.value),
+                    trygdetid(behandlingId, ident = avdoed2.value),
+                )
+            every { repository.hentTrygdetiderForAvdoede(any()) } returns
+                listOf(
+                    trygdetidPartial(annenBehandling.id, avdoed1),
+                    trygdetidPartial(annenBehandling.id, avdoed2),
+                )
+            coEvery { behandlingKlient.hentBehandling(annenBehandling.id, any()) } returns annenBehandling
+
+            val behandlingMedSammeAvdoede =
+                runBlocking {
+                    service.finnBehandlingMedTrygdetidForSammeAvdoede(behandlingId, saksbehandler)
+                }
+
+            behandlingMedSammeAvdoede shouldBe annenBehandling.id
+
+            verifyHentetAvdoedeFraGrunnlag(behandlingId)
+            verify(exactly = 1) {
+                repository.hentTrygdetiderForBehandling(behandlingId)
+                repository.hentTrygdetiderForAvdoede(listOf(avdoed1.value, avdoed2.value))
+            }
+            coVerify(exactly = 1) {
+                behandlingKlient.hentBehandling(annenBehandling.id, saksbehandler)
+            }
+        }
+
+        @Test
+        fun `finnBehandlingMedTrygdetidForSammeAvdoede skal bare ta med behandlinger som har alle avdøde`() {
+            val annenBehandling1 = behandling(randomUUID(), randomSakId(), BehandlingStatus.BEREGNET)
+            val annenBehandling2 = behandling(randomUUID(), randomSakId(), BehandlingStatus.BEREGNET)
+            val behandling = behandling(randomUUID(), randomSakId(), BehandlingStatus.ATTESTERT)
+            val avdoed1 = Folkeregisteridentifikator.of("10418305857")
+            val avdoed2 = Folkeregisteridentifikator.of("01448203510")
+
+            setupGrunnlagMock(listOf(avdoed1, avdoed2))
+
+            every { repository.hentTrygdetiderForBehandling(behandling.id) } returns
+                listOf(
+                    trygdetid(behandling.id, ident = avdoed1.value),
+                    trygdetid(behandling.id, ident = avdoed2.value),
+                )
+
+            every { repository.hentTrygdetiderForAvdoede(any()) } returns
+                listOf(
+                    trygdetidPartial(annenBehandling1.id, avdoed1),
+                    trygdetidPartial(annenBehandling1.id, avdoed2),
+                    trygdetidPartial(annenBehandling2.id, avdoed1),
+                    trygdetidPartial(behandling.id, avdoed1),
+                    trygdetidPartial(behandling.id, avdoed2),
+                )
+            coEvery { behandlingKlient.hentBehandling(annenBehandling1.id, any()) } returns annenBehandling1
+
+            val behandlingMedSammeAvdoede =
+                runBlocking {
+                    service.finnBehandlingMedTrygdetidForSammeAvdoede(behandling.id, saksbehandler)
+                }
+            behandlingMedSammeAvdoede shouldBe annenBehandling1.id
+
+            verifyHentetAvdoedeFraGrunnlag(behandling.id)
+            verify(exactly = 1) {
+                repository.hentTrygdetiderForBehandling(behandling.id)
+                repository.hentTrygdetiderForAvdoede(listOf(avdoed1.value, avdoed2.value))
+            }
+            coVerify(exactly = 1) {
+                behandlingKlient.hentBehandling(annenBehandling1.id, saksbehandler)
+            }
+        }
+
+        @Test
+        fun `finnBehandlingMedTrygdetidForSammeAvdoede skal ikke ta med den samme behandlingen`() {
+            val annenBehandling = behandling(randomUUID(), randomSakId(), BehandlingStatus.AVBRUTT)
+            val behandling = behandling(randomUUID(), randomSakId(), BehandlingStatus.ATTESTERT)
+            val avdoed1 = Folkeregisteridentifikator.of("10418305857")
+            val avdoed2 = Folkeregisteridentifikator.of("01448203510")
+
+            setupGrunnlagMock(listOf(avdoed1, avdoed2))
+
+            every { repository.hentTrygdetiderForBehandling(behandling.id) } returns
+                listOf(
+                    trygdetid(behandling.id, ident = avdoed1.value),
+                    trygdetid(behandling.id, ident = avdoed2.value),
+                )
+
+            every { repository.hentTrygdetiderForAvdoede(any()) } returns
+                listOf(
+                    trygdetidPartial(annenBehandling.id, avdoed1),
+                    trygdetidPartial(annenBehandling.id, avdoed2),
+                    trygdetidPartial(behandling.id, avdoed1),
+                    trygdetidPartial(behandling.id, avdoed2),
+                )
+            coEvery { behandlingKlient.hentBehandling(annenBehandling.id, any()) } returns annenBehandling
+
+            val behandlingMedSammeAvdoede =
+                runBlocking {
+                    service.finnBehandlingMedTrygdetidForSammeAvdoede(behandling.id, saksbehandler)
+                }
+            behandlingMedSammeAvdoede shouldBe null
+
+            verifyHentetAvdoedeFraGrunnlag(behandling.id)
+            verify(exactly = 1) {
+                repository.hentTrygdetiderForBehandling(behandling.id)
+                repository.hentTrygdetiderForAvdoede(listOf(avdoed1.value, avdoed2.value))
+            }
+            coVerify(exactly = 1) {
+                behandlingKlient.hentBehandling(annenBehandling.id, saksbehandler)
+            }
+        }
+
+        @Test
+        fun `finnBehandlingMedTrygdetidForSammeAvdoede skal finne behandling med en avdoed`() {
+            val annenBehandling = behandling(randomUUID(), randomSakId(), BehandlingStatus.BEREGNET)
+            val avdoed1 = Folkeregisteridentifikator.of("10418305857")
+
+            setupGrunnlagMock(listOf(avdoed1))
+            val behandlingId = randomUUID()
+
+            every { repository.hentTrygdetiderForBehandling(behandlingId) } returns
+                listOf(trygdetid(behandlingId, ident = avdoed1.value))
+            every { repository.hentTrygdetiderForAvdoede(any()) } returns
+                listOf(trygdetidPartial(annenBehandling.id, avdoed1))
+            coEvery { behandlingKlient.hentBehandling(annenBehandling.id, any()) } returns annenBehandling
+
+            val behandlingMedSammeAvdoede =
+                runBlocking {
+                    service.finnBehandlingMedTrygdetidForSammeAvdoede(behandlingId, saksbehandler)
+                }
+
+            behandlingMedSammeAvdoede shouldBe annenBehandling.id
+
+            verifyHentetAvdoedeFraGrunnlag(behandlingId)
+            verify(exactly = 1) {
+                repository.hentTrygdetiderForBehandling(behandlingId)
+                repository.hentTrygdetiderForAvdoede(listOf(avdoed1.value))
+            }
+            coVerify(exactly = 1) {
+                behandlingKlient.hentBehandling(annenBehandling.id, saksbehandler)
+            }
+        }
+
+        @Test
+        fun `kopierTrygdetidsgrunnlag skal feile hvis trygdetidene gjelder forskjellige avdøde`() {
+            val behandlingId = randomUUID()
+            val kildeBehandlingId = randomUUID()
+            every { repository.hentTrygdetiderForBehandling(behandlingId) } returns
+                listOf(
+                    trygdetid(
+                        behandlingId,
+                        ident = "01019012345",
+                    ),
+                )
+            every { repository.hentTrygdetiderForBehandling(kildeBehandlingId) } returns
+                listOf(
+                    trygdetid(behandlingId, ident = "01019012345"),
+                    trygdetid(behandlingId, ident = "24128512345"),
+                )
+            assertThrows<InternfeilException> {
+                runBlocking {
+                    service.kopierOgOverskrivTrygdetid(behandlingId, kildeBehandlingId, saksbehandler)
+                }
+            }
+            coVerify(exactly = 1) {
+                behandlingKlient.kanOppdatereTrygdetid(behandlingId, saksbehandler)
+                repository.hentTrygdetiderForBehandling(behandlingId)
+                repository.hentTrygdetiderForBehandling(kildeBehandlingId)
+            }
+        }
+
+        private fun trygdetidPartial(
+            behandlingId: UUID,
+            avdoed1: Folkeregisteridentifikator,
+        ) = TrygdetidPartial(behandlingId, avdoed1.value, Tidspunkt.now())
+    }
+
+    private fun beregnetTrygdetid() =
+        DetaljertBeregnetTrygdetid(
+            resultat =
+                DetaljertBeregnetTrygdetidResultat(
+                    faktiskTrygdetidNorge =
+                        FaktiskTrygdetid(
+                            periode = Period.ofYears(5),
+                            antallMaaneder = 5 * 12,
+                        ),
+                    faktiskTrygdetidTeoretisk = null,
+                    fremtidigTrygdetidNorge = null,
+                    fremtidigTrygdetidTeoretisk = null,
+                    samletTrygdetidNorge = 5,
+                    samletTrygdetidTeoretisk = null,
+                    prorataBroek = null,
+                    overstyrt = false,
+                    yrkesskade = false,
+                    beregnetSamletTrygdetidNorge = null,
+                ),
+            tidspunkt = Tidspunkt.now(),
+            regelResultat = "".toJsonNode(),
+        )
+
+    private fun <T : Any> konstantOpplysning(a: T): Opplysning.Konstant<JsonNode> {
+        val kilde = Grunnlagsopplysning.Pdl(Tidspunkt.now(), "", "")
+        return Opplysning.Konstant(randomUUID(), kilde, a.toJsonNode())
+    }
+
+    private fun grunnlagMedEkstraAvdoedForelder(
+        foedselsdato: LocalDate,
+        doedsdato: LocalDate,
+    ): Grunnlag {
+        val grunnlagEnAvdoed = GrunnlagTestData().hentOpplysningsgrunnlag()
+        val nyligAvdoedFoedselsnummer = AVDOED2_FOEDSELSNUMMER
+        val nyligAvdoed: Grunnlagsdata<JsonNode> =
+            mapOf(
+                Opplysningstype.DOEDSDATO to konstantOpplysning(doedsdato),
+                Opplysningstype.PERSONROLLE to konstantOpplysning(PersonRolle.AVDOED),
+                Opplysningstype.FOEDSELSNUMMER to konstantOpplysning(nyligAvdoedFoedselsnummer),
+                Opplysningstype.FOEDSELSDATO to konstantOpplysning(foedselsdato),
+            )
+        return GrunnlagTestData(
+            opplysningsmapAvdoedeOverrides = listOf(nyligAvdoed) + grunnlagEnAvdoed.hentAvdoede(),
+        ).hentOpplysningsgrunnlag()
+    }
+
+    private fun grunnlagUtenAvdoede(): Grunnlag {
+        val grunnlag =
+            GrunnlagTestData(
+                opplysningsmapAvdoedOverrides = emptyMap(),
+                opplysningsmapSakOverrides =
+                    mapOf(
+                        Opplysningstype.PERSONGALLERI_V1 to
+                            Opplysning.Konstant(
+                                randomUUID(),
+                                Grunnlagsopplysning.Pdl(Tidspunkt.now(), null, null),
+                                Persongalleri(
+                                    soeker = SOEKER_FOEDSELSNUMMER.value,
+                                    avdoed = emptyList(),
+                                ).toJsonNode(),
+                            ),
+                    ),
+            ).hentOpplysningsgrunnlag()
+        return grunnlag
+    }
+
+    private fun mockVedtak(
+        behandlingId: UUID,
+        type: VedtakType,
+    ) = VedtakSammendragDto(randomUUID().toString(), behandlingId, type, null, null, null, null, null, null)
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidTest.kt
@@ -1,0 +1,206 @@
+package no.nav.etterlatte.trygdetid
+
+import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDate
+
+internal class TrygdetidTest {
+    private val trygdetid =
+        trygdetid(
+            trygdetidGrunnlag =
+                listOf(
+                    trygdetidGrunnlag(
+                        periode =
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2017, 1, 1),
+                                til = LocalDate.of(2017, 6, 30),
+                            ),
+                    ),
+                    trygdetidGrunnlag(
+                        periode =
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2020, 1, 1),
+                                til = LocalDate.of(2020, 12, 31),
+                            ),
+                    ),
+                    trygdetidGrunnlag(
+                        periode =
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2022, 1, 1),
+                                til = LocalDate.of(2022, 12, 31),
+                            ),
+                    ),
+                ),
+        )
+
+    @Test
+    fun `Skal kunne legge til gyldige trygdetidsperioder`() {
+        val oppdatert =
+            trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(
+                trygdetidGrunnlag(
+                    periode =
+                        TrygdetidPeriode(
+                            fra = LocalDate.of(2018, 1, 1),
+                            til = LocalDate.of(2019, 12, 31),
+                        ),
+                ),
+            )
+        oppdatert.trygdetidGrunnlag.size shouldBe 4
+        oppdatert.trygdetidGrunnlag.any { it.periode.fra == LocalDate.of(2018, 1, 1) } shouldBe true
+    }
+
+    @Test
+    fun `Skal kaste feil ved overlapp av trygdetidsperiode paa slutten av perioden`() {
+        val overlappendePeriode =
+            trygdetidGrunnlag(
+                periode =
+                    TrygdetidPeriode(
+                        fra = LocalDate.of(2019, 5, 1),
+                        til = LocalDate.of(2020, 5, 15),
+                    ),
+            )
+
+        assertThrows<OverlappendePeriodeException> {
+            trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(overlappendePeriode)
+        }
+    }
+
+    @Test
+    fun `Skal kaste feil ved overlapp av trygdetidsperiode paa starten av perioden`() {
+        val overlappendePeriode =
+            trygdetidGrunnlag(
+                periode =
+                    TrygdetidPeriode(
+                        fra = LocalDate.of(2020, 5, 20),
+                        til = LocalDate.of(2021, 1, 1),
+                    ),
+            )
+
+        assertThrows<OverlappendePeriodeException> {
+            trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(overlappendePeriode)
+        }
+    }
+
+    @Test
+    fun `Skal kaste feil ved overlapp i midten av en periode`() {
+        val overlappendePeriode =
+            trygdetidGrunnlag(
+                periode =
+                    TrygdetidPeriode(
+                        fra = LocalDate.of(2020, 3, 20),
+                        til = LocalDate.of(2020, 6, 1),
+                    ),
+            )
+
+        assertThrows<OverlappendePeriodeException> {
+            trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(overlappendePeriode)
+        }
+    }
+
+    @Test
+    fun `Skal kaste feil ved overlapp over en periode`() {
+        val overlappendePeriode =
+            trygdetidGrunnlag(
+                periode =
+                    TrygdetidPeriode(
+                        fra = LocalDate.of(2019, 3, 20),
+                        til = LocalDate.of(2023, 6, 1),
+                    ),
+            )
+
+        assertThrows<OverlappendePeriodeException> {
+            trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(overlappendePeriode)
+        }
+    }
+
+    @Test
+    fun `Skal kaste feil ved overlapp over en periode med poeng aar`() {
+        val overlappendePeriode =
+            trygdetidGrunnlag(
+                poengInnAar = true,
+                periode =
+                    TrygdetidPeriode(
+                        fra = LocalDate.of(2017, 8, 31),
+                        til = LocalDate.of(2017, 12, 31),
+                    ),
+            )
+
+        assertThrows<OverlappendePeriodeException> {
+            trygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(overlappendePeriode)
+        }
+    }
+
+    @Test
+    fun `Skal kunne legge til uansett input sorteringsrekkefølge`() {
+        val usortertTrygdetid =
+            trygdetid(
+                trygdetidGrunnlag =
+                    listOf(
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2014, 5, 20), LocalDate.of(2027, 12, 31)),
+                            trygdetidType = TrygdetidType.FREMTIDIG,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2006, 1, 1), LocalDate.of(2014, 4, 30)),
+                            poengInnAar = true,
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2002, 1, 1), LocalDate.of(2005, 12, 31)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.POLEN.isoCode,
+                        ),
+                    ),
+            )
+
+        val oppdatert =
+            usortertTrygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(
+                trygdetidGrunnlag(
+                    periode = TrygdetidPeriode(LocalDate.of(2000, 6, 1), LocalDate.of(2000, 6, 18)),
+                    trygdetidType = TrygdetidType.FAKTISK,
+                ),
+            )
+
+        oppdatert.trygdetidGrunnlag.size shouldBe 4
+    }
+
+    @Test
+    fun `Skal kunne legge til grunnlag i vilkaarlig rekkefoelge ogsaa hvor det er poengaar som trigger endring av periode`() {
+        val usortertTrygdetid =
+            trygdetid(
+                trygdetidGrunnlag =
+                    listOf(
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2020, 7, 1), LocalDate.of(2020, 9, 1)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2022, 5, 1), LocalDate.of(2022, 8, 31)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2019, 2, 1), LocalDate.of(2019, 11, 30)),
+                            poengInnAar = true,
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                        trygdetidGrunnlag(
+                            periode = TrygdetidPeriode(LocalDate.of(2019, 12, 1), LocalDate.of(2020, 3, 28)),
+                            trygdetidType = TrygdetidType.FAKTISK,
+                        ),
+                    ),
+            )
+
+        val oppdatert =
+            usortertTrygdetid.leggTilEllerOppdaterTrygdetidGrunnlag(
+                trygdetidGrunnlag(
+                    periode = TrygdetidPeriode(LocalDate.of(2021, 5, 29), LocalDate.of(2021, 7, 27)),
+                    poengInnAar = true,
+                    trygdetidType = TrygdetidType.FAKTISK,
+                ),
+            )
+
+        oppdatert.trygdetidGrunnlag.size shouldBe 5
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleServiceTest.kt
@@ -1,0 +1,118 @@
+package no.nav.etterlatte.trygdetid.avtale
+
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.verify
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.trygdetid.trygdeavtale
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestInstance
+import java.time.LocalDate
+import java.time.Month
+import java.util.UUID.randomUUID
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+internal class AvtaleServiceTest {
+    private val repository = mockk<AvtaleRepository>()
+    private val service = AvtaleService(repository)
+
+    @BeforeEach
+    fun beforeEach() {
+        clearAllMocks()
+    }
+
+    @AfterEach
+    fun afterEach() {
+        confirmVerified()
+    }
+
+    @Test
+    fun `skal levere informasjon om avtaler`() {
+        val avtaler = service.hentAvtaler()
+
+        avtaler.size shouldBe 26
+        with(avtaler.first { it.kode == "EOS_NOR" }) {
+            this.beskrivelse shouldBe "Eøs-Avtalen/Nordisk Konvensjon"
+            this.fraDato shouldBe LocalDate.of(1899, Month.DECEMBER, 31)
+        }
+
+        with(avtaler.first { it.kode == "BIH" }) {
+            this.beskrivelse shouldBe "Bosnia-Hercegovina"
+            this.fraDato shouldBe LocalDate.of(1899, Month.DECEMBER, 31)
+
+            val trygdetidDato = this.datoer.first()
+
+            trygdetidDato.kode shouldBe "BIH1992"
+            trygdetidDato.beskrivelse shouldBe "01.03.1992"
+            trygdetidDato.fraDato shouldBe LocalDate.of(1899, Month.DECEMBER, 31)
+        }
+    }
+
+    @Test
+    fun `skal levere informasjon om avtale kriterier`() {
+        val avtaler = service.hentAvtaleKriterier()
+
+        avtaler.size shouldBe 7
+        with(avtaler.first { it.kode == "YRK_MEDL" }) {
+            this.beskrivelse shouldBe "Yrkesaktiv i Norge eller EØS, ett års medlemskap i Norge"
+            this.fraDato shouldBe LocalDate.of(1899, Month.DECEMBER, 31)
+        }
+    }
+
+    @Test
+    fun `skal kunne hente en avtale`() {
+        val behandlingId = randomUUID()
+
+        every { repository.hentAvtale(any()) } returns trygdeavtale(behandlingId, "TEST")
+
+        val avtale = service.hentAvtaleForBehandling(behandlingId)
+
+        avtale?.avtaleKode shouldBe "TEST"
+
+        verify(exactly = 1) { repository.hentAvtale(any()) }
+    }
+
+    @Test
+    fun `skal opprette avtaler`() {
+        val avtaleSlot = slot<Trygdeavtale>()
+        val behandlingId = randomUUID()
+
+        every { repository.opprettAvtale(capture(avtaleSlot)) } just runs
+
+        service.opprettAvtale(
+            trygdeavtale(behandlingId = behandlingId, avtaleKode = "TEST", avtaleDatoKode = "TESTDATO"),
+        )
+
+        avtaleSlot.captured.avtaleKode shouldBe "TEST"
+        avtaleSlot.captured.avtaleDatoKode shouldBe "TESTDATO"
+        avtaleSlot.captured.behandlingId shouldBe behandlingId
+
+        verify(exactly = 1) { repository.opprettAvtale(any()) }
+    }
+
+    @Test
+    fun `skal oppdatere avtaler`() {
+        val avtaleSlot = slot<Trygdeavtale>()
+        val behandlingId = randomUUID()
+
+        every { repository.lagreAvtale(capture(avtaleSlot)) } just runs
+
+        service.lagreAvtale(
+            trygdeavtale(behandlingId = behandlingId, avtaleKode = "TEST", avtaleKriteriaKode = "TESTKRITERIA"),
+        )
+
+        avtaleSlot.captured.avtaleKode shouldBe "TEST"
+        avtaleSlot.captured.avtaleKriteriaKode shouldBe "TESTKRITERIA"
+        avtaleSlot.captured.behandlingId shouldBe behandlingId
+
+        verify(exactly = 1) { repository.lagreAvtale(any()) }
+    }
+}

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/regler/BeregnTrygdetidTest.kt
@@ -1,0 +1,1387 @@
+package no.nav.etterlatte.trygdetid.regler
+
+import io.kotest.matchers.shouldBe
+import no.nav.etterlatte.libs.common.IntBroek
+import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
+import no.nav.etterlatte.libs.common.tidspunkt.Tidspunkt
+import no.nav.etterlatte.libs.common.trygdetid.DetaljertBeregnetTrygdetidResultat
+import no.nav.etterlatte.libs.common.trygdetid.FaktiskTrygdetid
+import no.nav.etterlatte.libs.common.trygdetid.FremtidigTrygdetid
+import no.nav.etterlatte.libs.common.trygdetid.land.LandNormalisert
+import no.nav.etterlatte.libs.regler.FaktumNode
+import no.nav.etterlatte.libs.regler.RegelPeriode
+import no.nav.etterlatte.trygdetid.TrygdetidGrunnlag
+import no.nav.etterlatte.trygdetid.TrygdetidPeriode
+import no.nav.etterlatte.trygdetid.TrygdetidType
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.LocalDate
+import java.time.Period
+import java.util.UUID
+import java.util.stream.Stream
+
+internal class BeregnTrygdetidTest {
+    @Test
+    fun `beregnTrygdetidMellomToDatoer skal gi en maaned naar periodeFra er dag 1 og periodeTil er siste dag i mnd`() {
+        val grunnlag =
+            TrygdetidPeriodeGrunnlag(
+                periode =
+                    FaktumNode(
+                        verdi =
+                            TrygdetidPeriodeMedPoengaar(
+                                fra = LocalDate.of(2023, 1, 1),
+                                til = LocalDate.of(2023, 1, 31),
+                                poengInnAar = false,
+                                poengUtAar = false,
+                            ),
+                        kilde = "Z1234",
+                        beskrivelse = "Periode",
+                    ),
+            )
+
+        val resultat = beregnTrygdetidForPeriode.anvend(grunnlag, RegelPeriode(LocalDate.now()))
+
+        resultat.verdi shouldBe Period.ofMonths(1)
+    }
+
+    @Test
+    fun `beregnTrygdetidMellomToDatoer skal gi en dag naar periodeFra og periodeTil er like`() {
+        val grunnlag =
+            TrygdetidPeriodeGrunnlag(
+                periode =
+                    FaktumNode(
+                        verdi =
+                            TrygdetidPeriodeMedPoengaar(
+                                fra = LocalDate.of(2023, 1, 1),
+                                til = LocalDate.of(2023, 1, 1),
+                                poengInnAar = false,
+                                poengUtAar = false,
+                            ),
+                        kilde = "Z1234",
+                        beskrivelse = "Periode",
+                    ),
+            )
+
+        val resultat = beregnTrygdetidForPeriode.anvend(grunnlag, RegelPeriode(LocalDate.now()))
+
+        resultat.verdi shouldBe Period.ofDays(1)
+    }
+
+    @Test
+    fun `beregnTrygdetidMellomToDatoer skal gi ett aar en maaned og en dag`() {
+        val grunnlag =
+            TrygdetidPeriodeGrunnlag(
+                periode =
+                    FaktumNode(
+                        verdi =
+                            TrygdetidPeriodeMedPoengaar(
+                                fra = LocalDate.of(2023, 1, 1),
+                                til = LocalDate.of(2024, 2, 1),
+                                poengInnAar = false,
+                                poengUtAar = false,
+                            ),
+                        kilde = "Z1234",
+                        beskrivelse = "Periode",
+                    ),
+            )
+
+        val resultat = beregnTrygdetidForPeriode.anvend(grunnlag, RegelPeriode(LocalDate.now()))
+
+        resultat.verdi shouldBe Period.of(1, 1, 1)
+    }
+
+    @ParameterizedTest(name = "fra {0} til {1} poengInnAar {2} poengUtAar {3} skal gi periode {4}")
+    @MethodSource("verdierForPoengaarTest")
+    fun `beregnTrygdetidMellomToDatoer skal ta hensyn til poengInnAar og poengUtAar`(
+        fra: LocalDate,
+        til: LocalDate,
+        poengInnAar: Boolean,
+        poengUtAar: Boolean,
+        forventetPeriode: Period,
+    ) {
+        val grunnlag =
+            TrygdetidPeriodeGrunnlag(
+                periode =
+                    FaktumNode(
+                        verdi =
+                            TrygdetidPeriodeMedPoengaar(
+                                fra = fra,
+                                til = til,
+                                poengInnAar = poengInnAar,
+                                poengUtAar = poengUtAar,
+                            ),
+                        kilde = "Z1234",
+                        beskrivelse = "Periode",
+                    ),
+            )
+
+        val resultat = beregnTrygdetidForPeriode.anvend(grunnlag, RegelPeriode(LocalDate.now()))
+
+        resultat.verdi shouldBe forventetPeriode
+    }
+
+    private fun totalTrygdetidGrunnlag(perioder: List<Period>) =
+        TotalTrygdetidGrunnlag(
+            FaktumNode(perioder, Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()), "Trygdetidsperioder"),
+        )
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("trygdetidGrunnlag")
+    fun `beregnDetaljertBeregnetTrygdetid skal beregne riktig`(
+        beskrivelse: String,
+        perioder: List<TrygdetidGrunnlag>,
+        forventet: DetaljertBeregnetTrygdetidResultat,
+        datoer: Pair<LocalDate, LocalDate>?,
+        norskPoengaar: Int?,
+        yrkesskade: Boolean,
+    ) {
+        val trygdetidGrunnlagMedAvdoedGrunnlag =
+            TrygdetidGrunnlagMedAvdoedGrunnlag(
+                trygdetidGrunnlagListe =
+                    FaktumNode(
+                        verdi = perioder,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Trygdetidsperioder",
+                    ),
+                foedselsDato =
+                    FaktumNode(
+                        verdi = datoer?.first ?: LocalDate.of(1981, 2, 21),
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Fødselsdato",
+                    ),
+                doedsDato =
+                    FaktumNode(
+                        verdi = datoer?.second ?: LocalDate.of(2023, 3, 15),
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Dødsdato",
+                    ),
+                norskPoengaar =
+                    FaktumNode(
+                        verdi = norskPoengaar,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Norske poengår",
+                    ),
+                yrkesskade =
+                    FaktumNode(
+                        verdi = yrkesskade,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Yrkesskade",
+                    ),
+                nordiskKonvensjon =
+                    FaktumNode(
+                        verdi = false,
+                        kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+                        beskrivelse = "Nordisk konvensjon",
+                    ),
+            )
+
+        val resultat =
+            beregnDetaljertBeregnetTrygdetidMedYrkesskade.anvend(
+                trygdetidGrunnlagMedAvdoedGrunnlag,
+                RegelPeriode(LocalDate.now()),
+            )
+
+        resultat.verdi shouldBe forventet
+    }
+
+    companion object {
+        @JvmStatic
+        fun verdierForPoengaarTest(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 30), false, false, Period.ofDays(21)),
+                Arguments.of(LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 30), false, true, Period.of(0, 7, 22)),
+                Arguments.of(LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 30), true, false, Period.of(0, 4, 30)),
+                Arguments.of(LocalDate.of(2023, 5, 10), LocalDate.of(2023, 5, 30), true, true, Period.ofYears(1)),
+                Arguments.of(LocalDate.of(2020, 2, 10), LocalDate.of(2023, 5, 30), false, false, Period.of(3, 3, 21)),
+                Arguments.of(LocalDate.of(2020, 2, 10), LocalDate.of(2023, 5, 30), false, true, Period.of(3, 10, 22)),
+                Arguments.of(LocalDate.of(2020, 2, 10), LocalDate.of(2023, 5, 30), true, false, Period.of(3, 4, 30)),
+                Arguments.of(LocalDate.of(2020, 2, 10), LocalDate.of(2023, 5, 30), true, true, Period.ofYears(4)),
+                // Justering poeng inn år gjør ingen forskjell hvis vi starter perioden 1.januar
+                Arguments.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 3, 4), true, false, Period.of(0, 2, 4)),
+                Arguments.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 3, 4), false, false, Period.of(0, 2, 4)),
+                // Justering poeng ut år gjør ingen forskjell hvis vi slutter perioden 31. desember
+                Arguments.of(LocalDate.of(2020, 6, 1), LocalDate.of(2020, 12, 31), false, true, Period.of(0, 7, 0)),
+                Arguments.of(LocalDate.of(2020, 6, 1), LocalDate.of(2020, 12, 31), false, false, Period.of(0, 7, 0)),
+                // Helt år har ingen ting å si hva du krysser av inn/ut
+                Arguments.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31), false, false, Period.ofYears(1)),
+                Arguments.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31), true, false, Period.ofYears(1)),
+                Arguments.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31), false, true, Period.ofYears(1)),
+                Arguments.of(LocalDate.of(2020, 1, 1), LocalDate.of(2020, 12, 31), true, true, Period.ofYears(1)),
+            )
+
+        @JvmStatic
+        fun trygdetidGrunnlag(): Stream<Arguments> =
+            Stream.of(
+                Arguments.of(
+                    // ...arguments =
+                    "Nasjonal ikke poengAar",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 4, 2),
+                                til = LocalDate.of(2023, 6, 9),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(0, 3, 0),
+                                antallMaaneder = 3,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(0, 3, 0),
+                                antallMaaneder = 3,
+                            ),
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 0,
+                        samletTrygdetidTeoretisk = 0,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    null,
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Nasjonal poengInnAar",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 4, 2),
+                                til = LocalDate.of(2023, 6, 9),
+                            ),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(0, 6, 0),
+                                antallMaaneder = 6,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(0, 6, 0),
+                                antallMaaneder = 6,
+                            ),
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 0,
+                        samletTrygdetidTeoretisk = 0,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    null,
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Nasjonal poengUtAar",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 4, 2),
+                                til = LocalDate.of(2023, 6, 9),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(0, 9, 0),
+                                antallMaaneder = 9,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(0, 9, 0),
+                                antallMaaneder = 9,
+                            ),
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 1,
+                        samletTrygdetidTeoretisk = 1,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    null,
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Nasjonal poengInnAar og poengUtAar",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 4, 2),
+                                til = LocalDate.of(2023, 6, 9),
+                            ),
+                            poengInnAar = true,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(1, 0, 0),
+                                antallMaaneder = 12,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(1, 0, 0),
+                                antallMaaneder = 12,
+                            ),
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 1,
+                        samletTrygdetidTeoretisk = 1,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    null,
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Utland",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(1992, 10, 3),
+                                til = LocalDate.of(2004, 12, 12),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.SVERIGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2005, 1, 1),
+                                til = LocalDate.of(2016, 12, 16),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2017, 1, 1),
+                                til = LocalDate.of(2022, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FREMTIDIG,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 1, 29),
+                                til = LocalDate.of(2042, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(18, 3, 0),
+                                antallMaaneder = 219,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(30, 3, 0),
+                                antallMaaneder = 363,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(15, 10, 0),
+                                antallMaaneder = 190,
+                                opptjeningstidIMaaneder = 362,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(20, 0, 0),
+                                antallMaaneder = 240,
+                                opptjeningstidIMaaneder = 362,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = false,
+                            ),
+                        samletTrygdetidNorge = 34,
+                        samletTrygdetidTeoretisk = 40,
+                        prorataBroek = IntBroek(219, 363),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(1976, 10, 3),
+                        LocalDate.of(2023, 1, 29),
+                    ),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Utland 2",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(1997, 2, 21),
+                                til = LocalDate.of(2010, 12, 17),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.SVERIGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2011, 1, 1),
+                                til = LocalDate.of(2023, 2, 28),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FREMTIDIG,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 3, 15),
+                                til = LocalDate.of(2047, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(13, 11, 0),
+                                antallMaaneder = 167,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(26, 1, 0),
+                                antallMaaneder = 313,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(19, 2, 0),
+                                antallMaaneder = 230,
+                                opptjeningstidIMaaneder = 312,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(24, 10, 0),
+                                antallMaaneder = 298,
+                                opptjeningstidIMaaneder = 312,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = false,
+                            ),
+                        samletTrygdetidNorge = 33,
+                        samletTrygdetidTeoretisk = 40,
+                        prorataBroek = IntBroek(167, 313),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(1981, 2, 21),
+                        LocalDate.of(2023, 3, 15),
+                    ),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Utland 3",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.SVERIGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2011, 1, 1),
+                                til = LocalDate.of(2023, 2, 28),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FREMTIDIG,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 3, 15),
+                                til = LocalDate.of(2047, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge = FaktiskTrygdetid(Period.ZERO, 0),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(12, 2, 0),
+                                antallMaaneder = 146,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(19, 2, 0),
+                                antallMaaneder = 230,
+                                opptjeningstidIMaaneder = 312,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(19, 2, 0),
+                                antallMaaneder = 230,
+                                opptjeningstidIMaaneder = 312,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        samletTrygdetidNorge = 19,
+                        samletTrygdetidTeoretisk = 31,
+                        prorataBroek = IntBroek(teller = 0, nevner = 146),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(1981, 2, 21),
+                        LocalDate.of(2023, 3, 15),
+                    ),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Utland med overstyrt norsk poengaar",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2010, 1, 1),
+                                til = LocalDate.of(2010, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.SVERIGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2011, 1, 1),
+                                til = LocalDate.of(2023, 2, 28),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FREMTIDIG,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 3, 15),
+                                til = LocalDate.of(2047, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.ofYears(2),
+                                antallMaaneder = 24,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(14, 2, 0),
+                                antallMaaneder = 170,
+                            ),
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 2,
+                        samletTrygdetidTeoretisk = 14,
+                        prorataBroek = IntBroek(24, 170),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(1981, 2, 21),
+                        LocalDate.of(2023, 3, 15),
+                    ),
+                    2,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Skal ikke treffe 4/5 regel hvis 18/20 år er opptjening",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2023, 2, 21).minusYears(18),
+                                til = LocalDate.of(2023, 2, 21),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FREMTIDIG,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2023, 2, 21),
+                                    til = LocalDate.of(2023, 2, 21).plusYears(30),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(18, 1, 0),
+                                antallMaaneder = 217,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(18, 1, 0),
+                                antallMaaneder = 217,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(30, 11, 0),
+                                antallMaaneder = 371,
+                                opptjeningstidIMaaneder = 239,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = false,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(30, 11, 0),
+                                antallMaaneder = 371,
+                                opptjeningstidIMaaneder = 239,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = false,
+                            ),
+                        samletTrygdetidNorge = 40,
+                        samletTrygdetidTeoretisk = 40,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(2023, 2, 21).minusYears(36),
+                        LocalDate.of(2023, 2, 21),
+                    ),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Skal ikke treffe 4/5 regel hvis nordisk konvensjon",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.SVERIGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2013, 5, 1),
+                                til = LocalDate.of(2018, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2019, 1, 1),
+                                til = LocalDate.of(2024, 9, 30),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FREMTIDIG,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2024, 10, 15),
+                                    til = LocalDate.of(2041, 10, 20),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(5, 9, 0),
+                                antallMaaneder = 69,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(11, 5, 0),
+                                antallMaaneder = 137,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        samletTrygdetidNorge = 29,
+                        samletTrygdetidTeoretisk = 34,
+                        prorataBroek = IntBroek(teller = 69, nevner = 137),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(2023, 2, 21).minusYears(36),
+                        LocalDate.of(2023, 2, 21),
+                    ),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Skal ikke få mer enn 40 år i brøken",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(1974, 12, 11),
+                                til = LocalDate.of(1994, 6, 1),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.DANMARK.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(1996, 1, 1),
+                                til = LocalDate.of(2015, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FREMTIDIG,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2015, 1, 7),
+                                    til =
+
+                                        LocalDate.of(2024, 12, 31),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(20, 1, 0),
+                                antallMaaneder = 241,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(40, 1, 0),
+                                antallMaaneder = 481,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(7, 11, 0),
+                                antallMaaneder = 95,
+                                opptjeningstidIMaaneder = 481,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(10, 0, 0),
+                                antallMaaneder = 120,
+                                opptjeningstidIMaaneder = 481,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = false,
+                            ),
+                        samletTrygdetidNorge = 28,
+                        samletTrygdetidTeoretisk = 40,
+                        prorataBroek = IntBroek(241, 480),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    Pair(
+                        LocalDate.of(1958, 11, 12),
+                        LocalDate.of(2015, 1, 7),
+                    ),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Nasjonal ikke poengAar med yrkesskade",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2022, 4, 2),
+                                til = LocalDate.of(2023, 6, 9),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(1, 3, 0),
+                                antallMaaneder = 15,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(1, 3, 0),
+                                antallMaaneder = 15,
+                            ),
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 40,
+                        samletTrygdetidTeoretisk = 1,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = true,
+                        beregnetSamletTrygdetidNorge = 1,
+                    ),
+                    null,
+                    null,
+                    true,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Ikke mer enn en oppjustering",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.POLEN.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(1994, 2, 10),
+                                til = LocalDate.of(2004, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.STORBRITANNIA.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2005, 3, 2),
+                                til = LocalDate.of(2008, 12, 31),
+                            ),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.DANMARK.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2009, 1, 1),
+                                til = LocalDate.of(2011, 12, 12),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.POLEN.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2012, 11, 1),
+                                til = LocalDate.of(2012, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.DANMARK.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2014, 5, 23),
+                                til = LocalDate.of(2019, 3, 25),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.POLEN.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2019, 10, 1),
+                                til = LocalDate.of(2019, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2013, 6, 1),
+                                til = LocalDate.of(2014, 5, 4),
+                            ),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.DANMARK.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2020, 6, 1),
+                                til = LocalDate.of(2021, 6, 3),
+                            ),
+                            poengInnAar = true,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FAKTISK,
+                            LandNormalisert.POLEN.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2022, 1, 1),
+                                til = LocalDate.of(2022, 7, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            TrygdetidType.FREMTIDIG,
+                            LandNormalisert.NORGE.isoCode,
+                            TrygdetidPeriode(
+                                fra = LocalDate.of(2022, 8, 23),
+                                til = LocalDate.of(2044, 12, 31),
+                            ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = false,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(1, 5, 0),
+                                antallMaaneder = 17,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(27, 1, 0),
+                                antallMaaneder = 325,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(19, 8, 0),
+                                antallMaaneder = 236,
+                                opptjeningstidIMaaneder = 305,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 5, 0),
+                                antallMaaneder = 269,
+                                opptjeningstidIMaaneder = 305,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = false,
+                            ),
+                        samletTrygdetidNorge = 21,
+                        samletTrygdetidTeoretisk = 40,
+                        prorataBroek = IntBroek(17, 325),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    null,
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Tester detaljer i avrunding mellom pesys og Gjenny",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FREMTIDIG,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2024, 2, 28),
+                                    til = LocalDate.of(2045, 12, 31),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = false,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.DANMARK.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(1995, 6, 4),
+                                    til = LocalDate.of(2015, 12, 30),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode = TrygdetidPeriode(fra = LocalDate.of(2017, 1, 1), til = LocalDate.of(2017, 3, 6)),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2018, 8, 17),
+                                    til = LocalDate.of(2018, 11, 27),
+                                ),
+                            poengInnAar = true,
+                            poengUtAar = true,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.DANMARK.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2017, 5, 10),
+                                    til = LocalDate.of(2017, 8, 31),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.DANMARK.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2021, 10, 1),
+                                    til = LocalDate.of(2021, 12, 31),
+                                ),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode = TrygdetidPeriode(fra = LocalDate.of(2022, 6, 3), til = LocalDate.of(2024, 1, 31)),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(3, 4, 0),
+                                antallMaaneder = 40,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(25, 2, 0),
+                                antallMaaneder = 302,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(17, 2, 0),
+                                antallMaaneder = 206,
+                                opptjeningstidIMaaneder = 343,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(21, 11, 0),
+                                antallMaaneder = 263,
+                                opptjeningstidIMaaneder = 343,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = false,
+                            ),
+                        samletTrygdetidNorge = 21,
+                        samletTrygdetidTeoretisk = 40,
+                        prorataBroek = IntBroek(40, 302),
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    LocalDate.of(1979, 6, 4) to LocalDate.of(2024, 2, 28),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Sjekker opprunding av faktisk trygdetid foer addering med framtidig trygdetid",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FREMTIDIG,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2022, 10, 19),
+                                    til = LocalDate.of(2051, 12, 31),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = false,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2012, 7, 25),
+                                    til = LocalDate.of(2022, 9, 30),
+                                ),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(10, 9, 0),
+                                antallMaaneder = 129,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(10, 9, 0),
+                                antallMaaneder = 129,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        samletTrygdetidNorge = 34,
+                        samletTrygdetidTeoretisk = 34,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    LocalDate.of(1985, 2, 16) to LocalDate.of(2022, 10, 19),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    // ...arguments =
+                    "Sjekker opprunding av faktisk trygdetid foer addering med framtidig trygdetid",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2012, 7, 25),
+                                    til = LocalDate.of(2022, 9, 30),
+                                ),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FREMTIDIG,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2022, 10, 19),
+                                    til = LocalDate.of(2051, 12, 31),
+                                ),
+                            poengInnAar = false,
+                            poengUtAar = false,
+                            medIProrata = false,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(10, 9, 0),
+                                antallMaaneder = 129,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(10, 9, 0),
+                                antallMaaneder = 129,
+                            ),
+                        fremtidigTrygdetidNorge =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        fremtidigTrygdetidTeoretisk =
+                            FremtidigTrygdetid(
+                                periode = Period.of(22, 9, 0),
+                                antallMaaneder = 273,
+                                opptjeningstidIMaaneder = 259,
+                                mindreEnnFireFemtedelerAvOpptjeningstiden = true,
+                            ),
+                        samletTrygdetidNorge = 34,
+                        samletTrygdetidTeoretisk = 34,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    LocalDate.of(1985, 2, 16) to LocalDate.of(2022, 10, 19),
+                    null,
+                    false,
+                ),
+                Arguments.of(
+                    "Runder ikke opp faktisk trygdetid hvis ingen framtidig trygdetid",
+                    listOf(
+                        byggTrygdetidGrunnlag(
+                            type = TrygdetidType.FAKTISK,
+                            bosted = LandNormalisert.NORGE.isoCode,
+                            periode =
+                                TrygdetidPeriode(
+                                    fra = LocalDate.of(2012, 7, 25),
+                                    til = LocalDate.of(2022, 6, 17),
+                                ),
+                            poengInnAar = true,
+                            poengUtAar = false,
+                            medIProrata = true,
+                        ),
+                    ),
+                    DetaljertBeregnetTrygdetidResultat(
+                        faktiskTrygdetidNorge =
+                            FaktiskTrygdetid(
+                                periode = Period.of(10, 6, 0),
+                                antallMaaneder = 126,
+                            ),
+                        faktiskTrygdetidTeoretisk =
+                            FaktiskTrygdetid(
+                                periode = Period.of(10, 6, 0),
+                                antallMaaneder = 126,
+                            ),
+                        fremtidigTrygdetidNorge = null,
+                        fremtidigTrygdetidTeoretisk = null,
+                        samletTrygdetidNorge = 10,
+                        samletTrygdetidTeoretisk = 10,
+                        prorataBroek = null,
+                        overstyrt = false,
+                        yrkesskade = false,
+                        beregnetSamletTrygdetidNorge = null,
+                    ),
+                    null,
+                    null,
+                    false,
+                ),
+            )
+
+        private fun byggTrygdetidGrunnlag(
+            type: TrygdetidType,
+            bosted: String,
+            periode: TrygdetidPeriode,
+            poengInnAar: Boolean,
+            poengUtAar: Boolean,
+            medIProrata: Boolean,
+        ) = TrygdetidGrunnlag(
+            id = UUID.randomUUID(),
+            type = type,
+            bosted = bosted,
+            periode = periode,
+            kilde = Grunnlagsopplysning.Saksbehandler("Z12345", Tidspunkt.now()),
+            null,
+            null,
+            poengInnAar,
+            poengUtAar,
+            medIProrata,
+        )
+    }
+}


### PR DESCRIPTION
 Kopiert fra etterlatte-trygdetid:
 - TrygdetidService (interface + impl)
 - TrygdetidBeregningService
 - avtale/AvtaleService
 - regler/BeregnTrygdetid + BeregnTrygdetidGrunnlag
 - klienter/ (BehandlingKlient, GrunnlagKlient, PesysKlient, VedtaksvurderingKlient, VedtaksvurderingBehandlingKlient)
 - JSON-ressurser for trygdeavtaler

 Lagt til TrygdetidMapper.kt med Trygdetid.toDto() og tilhørende
 mapping-funksjoner som lå i TrygdetidRoutes.kt i kildeappen.

 Tilhørende tester er kopiert og kjører grønt:
 TrygdetidServiceTest, TrygdetidServiceIntegrationTest,
 TrygdetidBeregningServiceTest, TrygdetidTest,
 AvtaleServiceTest, BeregnTrygdetidTest