### PR TITLE
Trygdetid migrering crud

### DIFF
--- a/.github/lessons.md
+++ b/.github/lessons.md
@@ -64,3 +64,7 @@
 **2026-06-17 — REST-databaselag med toggle**
 - Observation: Toggle-logikk for kilde-valg hørte hjemme på wiring-nivå (ServiceModule), ikke spredt som sjekker i service-metodene. Når servicen alltid "oppfører seg", og korrekt implementasjon er injisert via interface, trengs ingen toggle-sjekk i logikken.
 - Action: Flytt toggle-logikk til komposeringsnivå (ApplicationContext/ServiceModule). Serviceklasser skal aldri sjekke toggles for å velge datakilde – det er DI sin jobb.
+
+**2026-06-22 — Transaksjonskontext ved intern migrering**
+- Observation: Brute-force lesing av kode for å finne logikkforskjeller – uten å trace infrastruktur-forutsetningene – kostet mange omganger. Feilen lå ikke i forretningslogikken, men i at `ConnectionAutoclosing.hentConnection` krever en åpen transaksjon når `Kontekst` er satt, og den nye route-laget manglet `inTransaction`.
+- Action: Ved migrering av logikk fra en app til en annen – sjekk infrastruktur-kontrakten (transaksjonsoppsett, Kontekst, DB-tilkoblingsmønster) like grundig som forretningslogikken. Finn tidlig "hvem setter opp DB-konteksten i den nye appen?"

--- a/.github/lessons.md
+++ b/.github/lessons.md
@@ -61,3 +61,6 @@
 **2026-06-12 — Implementasjon vs. test-kontrakten**
 - Observation: Ny implementasjon konsoliderte to `hentGrunnlag`-kall til ett, men testene forventet `exactly = 2`. Dette var en korrekt forbedring, men det krevde oppdatering av testpåstander som ikke var åpenbare i forkant.
 - Action: Ved refaktorering fra HTTP-klient til intern service: tell forventede kall i den NYE impl., ikke den gamle. Den nye kan optimalisere (f.eks. cache grunnlag lokalt i scope) — sjekk om `exactly = N` i testene reflekterer ny eller gammel oppførsel.
+**2026-06-17 — REST-databaselag med toggle**
+- Observation: Toggle-logikk for kilde-valg hørte hjemme på wiring-nivå (ServiceModule), ikke spredt som sjekker i service-metodene. Når servicen alltid "oppfører seg", og korrekt implementasjon er injisert via interface, trengs ingen toggle-sjekk i logikken.
+- Action: Flytt toggle-logikk til komposeringsnivå (ApplicationContext/ServiceModule). Serviceklasser skal aldri sjekke toggles for å velge datakilde – det er DI sin jobb.

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -170,7 +170,7 @@ spec:
     - name: BRUK_INTERN_TRYGDETID
       value: "true"
     - name: BRUK_EGEN_DATABASE_FOR_TRYGDETID
-      value: "false"
+      value: "true"
 
   envFrom:
     - secret: my-application-unleash-api-token

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -142,7 +142,7 @@ spec:
     - name: OPPGAVE_URL
       value: https://oppgave.dev-fss-pub.nais.io
     - name: PEN_URL
-      value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen
+      value: https://pensjon-pen-q2.dev-fss-pub.nais.io
     - name: PEN_CLIENT_ID
       value: ddd52335-cfe8-4ee9-9e68-416a5ab26efa
     - name: KRR_ENDPOINT_URL

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -170,7 +170,7 @@ spec:
     - name: BRUK_INTERN_TRYGDETID
       value: "true"
     - name: BRUK_EGEN_DATABASE_FOR_TRYGDETID
-      value: "true"
+      value: "false"
 
   envFrom:
     - secret: my-application-unleash-api-token

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -168,7 +168,7 @@ spec:
     - name: SAMORDNEVEDTAK_AZURE_SCOPE
       value: api://dev-fss.pensjonsamhandling.sam-q2/.default
     - name: BRUK_INTERN_TRYGDETID
-      value: "false"
+      value: "true"
     - name: BRUK_EGEN_DATABASE_FOR_TRYGDETID
       value: "false"
 

--- a/apps/etterlatte-behandling/.nais/dev.yaml
+++ b/apps/etterlatte-behandling/.nais/dev.yaml
@@ -142,7 +142,7 @@ spec:
     - name: OPPGAVE_URL
       value: https://oppgave.dev-fss-pub.nais.io
     - name: PEN_URL
-      value: https://pensjon-pen-q2.dev-fss-pub.nais.io/api
+      value: https://pensjon-pen-q2.dev-fss-pub.nais.io/pen
     - name: PEN_CLIENT_ID
       value: ddd52335-cfe8-4ee9-9e68-416a5ab26efa
     - name: KRR_ENDPOINT_URL

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -182,7 +182,7 @@ spec:
     - name: SAMORDNEVEDTAK_AZURE_SCOPE
       value: api://prod-fss.pensjonsamhandling.sam/.default
     - name: BRUK_INTERN_TRYGDETID
-      value: "false"
+      value: "true"
     - name: BRUK_EGEN_DATABASE_FOR_TRYGDETID
       value: "false"
 

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -156,7 +156,7 @@ spec:
     - name: OPPGAVE_URL
       value: https://oppgave.prod-fss-pub.nais.io
     - name: PEN_URL
-      value: https://pensjon-pen.prod-fss-pub.nais.io/api
+      value: https://pensjon-pen.prod-fss-pub.nais.io/pen
     - name: PEN_CLIENT_ID
       value: 53eaf67f-d7b2-46e9-8ffe-3da7cf0ac955
     - name: KRR_ENDPOINT_URL

--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -156,7 +156,7 @@ spec:
     - name: OPPGAVE_URL
       value: https://oppgave.prod-fss-pub.nais.io
     - name: PEN_URL
-      value: https://pensjon-pen.prod-fss-pub.nais.io/pen
+      value: https://pensjon-pen.prod-fss-pub.nais.io
     - name: PEN_CLIENT_ID
       value: 53eaf67f-d7b2-46e9-8ffe-3da7cf0ac955
     - name: KRR_ENDPOINT_URL

--- a/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
@@ -135,4 +135,13 @@ fun <T> inTransaction(block: () -> T): T =
         block()
     }
 
+fun <T> inTransactionIfNeeded(block: () -> T): T {
+    val kontekst = Kontekst.get()
+    return if (kontekst != null && !kontekst.databasecontxt.harIntransaction()) {
+        kontekst.databasecontxt.inTransaction(block)
+    } else {
+        block()
+    }
+}
+
 fun databaseContext() = Kontekst.get().databasecontxt

--- a/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/Contekst.kt
@@ -136,8 +136,10 @@ fun <T> inTransaction(block: () -> T): T =
     }
 
 fun <T> inTransactionIfNeeded(block: () -> T): T {
-    val kontekst = Kontekst.get()
-    return if (kontekst != null && !kontekst.databasecontxt.harIntransaction()) {
+    val kontekst =
+        Kontekst.get()
+            ?: throw IllegalStateException("Kontekst er ikke satt – inTransactionIfNeeded kan ikke brukes utenfor en request-kontekst")
+    return if (!kontekst.databasecontxt.harIntransaction()) {
         kontekst.databasecontxt.inTransaction(block)
     } else {
         block()

--- a/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PesysKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/common/klienter/PesysKlient.kt
@@ -43,7 +43,7 @@ class PesysKlientImpl(
                 resource =
                     Resource(
                         clientId = clientId,
-                        url = "$resourceUrl/sak/sammendrag/v2",
+                        url = "$resourceUrl/api/sak/sammendrag/v2",
                         additionalHeaders = mapOf("fnr" to fnr),
                     ),
                 brukerTokenInfo = bruker,

--- a/apps/etterlatte-behandling/src/main/kotlin/config/modules/KlientModule.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/modules/KlientModule.kt
@@ -48,6 +48,8 @@ import no.nav.etterlatte.libs.ktor.httpClient
 import no.nav.etterlatte.libs.ktor.httpClientClientCredentials
 import no.nav.etterlatte.oppgaveGosys.GosysOppgaveKlient
 import no.nav.etterlatte.oppgaveGosys.GosysOppgaveKlientImpl
+import no.nav.etterlatte.trygdetid.TrygdetidRepositoryKlient
+import no.nav.etterlatte.trygdetid.avtale.AvtaleRepositoryKlient
 import no.nav.etterlatte.trygdetid.klienter.PesysKlient as TrygdetidPesysKlient
 import no.nav.etterlatte.trygdetid.klienter.PesysKlientImpl as TrygdetidPesysKlientImpl
 
@@ -111,6 +113,14 @@ class KlientModule(
 
     val trygdetidKlient: TrygdetidKlient by lazy {
         trygdetidKlientOverride ?: TrygdetidKlientImpl(config = config, httpClient = standardHttpClient)
+    }
+
+    val trygdetidRepositoryKlient: TrygdetidRepositoryKlient by lazy {
+        TrygdetidRepositoryKlient(config = config, httpClient = standardHttpClient)
+    }
+
+    val avtaleRepositoryKlient: AvtaleRepositoryKlient by lazy {
+        AvtaleRepositoryKlient(config = config, httpClient = standardHttpClient)
     }
 
     val gosysOppgaveKlient: GosysOppgaveKlient by lazy {

--- a/apps/etterlatte-behandling/src/main/kotlin/config/modules/ServiceModule.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/config/modules/ServiceModule.kt
@@ -480,19 +480,27 @@ class ServiceModule(
     private val brukInternTrygdetid: Boolean by lazy { env[BRUK_INTERN_TRYGDETID] == "true" }
     private val brukEgenDatabaseForTrygdetid: Boolean by lazy { env[BRUK_EGEN_DATABASE_FOR_TRYGDETID] == "true" }
 
-    val internTrygdetidAktivert: Boolean by lazy { brukInternTrygdetid && brukEgenDatabaseForTrygdetid }
+    val internTrygdetidAktivert: Boolean by lazy { brukInternTrygdetid }
 
     val avtaleService: AvtaleService by lazy {
-        AvtaleService(
-            avtaleRepository = daoModule.avtaleRepository,
-            brukInternTrygdetid = brukInternTrygdetid,
-            brukEgenDatabaseForTrygdetid = brukEgenDatabaseForTrygdetid,
-        )
+        val avtaleRepository =
+            if (brukEgenDatabaseForTrygdetid) {
+                daoModule.avtaleRepository
+            } else {
+                klientModule.avtaleRepositoryKlient
+            }
+        AvtaleService(avtaleRepository = avtaleRepository)
     }
 
     val trygdetidService: TrygdetidService by lazy {
+        val trygdetidRepository =
+            if (brukEgenDatabaseForTrygdetid) {
+                daoModule.trygdetidRepository
+            } else {
+                klientModule.trygdetidRepositoryKlient
+            }
         TrygdetidServiceImpl(
-            trygdetidRepository = daoModule.trygdetidRepository,
+            trygdetidRepository = trygdetidRepository,
             behandlingService = behandlingService,
             grunnlagService = grunnlagService,
             beregnTrygdetidService = TrygdetidBeregningService,
@@ -500,8 +508,6 @@ class ServiceModule(
             avtaleService = avtaleService,
             behandlingsStatusService = behandlingsStatusService,
             vedtaksvurderingKlient = VedtaksvurderingKlientAdapter(vedtaksvurderingService),
-            brukInternTrygdetid = brukInternTrygdetid,
-            brukEgenDatabaseForTrygdetid = brukEgenDatabaseForTrygdetid,
         )
     }
 }

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -162,7 +162,7 @@ class TrygdetidRepository(
                         tx,
                     )
                 } else {
-                    nullstillBeregnetTrygdetid(oppdatertTrygdetid.behandlingId, tx)
+                    nullstillBeregnetTrygdetid(oppdatertTrygdetid.behandlingId, oppdatertTrygdetid.id, tx)
                 }
             }.let { hentTrygdetidMedIdNotNull(oppdatertTrygdetid.behandlingId, oppdatertTrygdetid.id) }
 
@@ -535,6 +535,7 @@ class TrygdetidRepository(
 
     private fun nullstillBeregnetTrygdetid(
         behandlingId: UUID,
+        trygdetidId: UUID,
         tx: TransactionalSession,
     ) = queryOf(
         statement =
@@ -562,9 +563,9 @@ class TrygdetidRepository(
                 beregnet_trygdetid_overstyrt = false,
                 yrkesskade = false,
                 overstyrt_begrunnelse = null
-            WHERE behandling_id = :behandlingId
+            WHERE behandling_id = :behandlingId AND id = :trygdetidId
             """.trimIndent(),
-        paramMap = mapOf("behandlingId" to behandlingId),
+        paramMap = mapOf("behandlingId" to behandlingId, "trygdetidId" to trygdetidId),
     ).let { query -> tx.update(query) }
 
     private fun hentTrygdetidGrunnlag(trygdetidId: UUID): List<TrygdetidGrunnlag> =

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -24,15 +24,15 @@ import javax.sql.DataSource
 
 class TrygdetidRepository(
     private val dataSource: DataSource,
-) {
-    fun hentTrygdetidMedId(
+) : TrygdetidRepositoryOperasjoner {
+    override fun hentTrygdetidMedId(
         behandlingId: UUID,
         trygdetidId: UUID,
     ): Trygdetid? = hentTrygdetiderForBehandling(behandlingId).find { it.id == trygdetidId }
 
-    fun hentTrygdetid(behandlingId: UUID): Trygdetid? = hentTrygdetiderForBehandling(behandlingId).minByOrNull { it.ident }
+    override fun hentTrygdetid(behandlingId: UUID): Trygdetid? = hentTrygdetiderForBehandling(behandlingId).minByOrNull { it.ident }
 
-    fun hentTrygdetiderForBehandling(behandlingId: UUID): List<Trygdetid> =
+    override fun hentTrygdetiderForBehandling(behandlingId: UUID): List<Trygdetid> =
         using(sessionOf(dataSource)) { session ->
             queryOf(
                 statement =
@@ -85,7 +85,7 @@ class TrygdetidRepository(
             }
         }
 
-    fun opprettTrygdetid(trygdetid: Trygdetid): Trygdetid =
+    override fun opprettTrygdetid(trygdetid: Trygdetid): Trygdetid =
         dataSource
             .transaction { tx ->
                 opprettTrygdetid(trygdetid, tx)
@@ -97,7 +97,7 @@ class TrygdetidRepository(
                 }
             }.let { hentTrygdetidMedIdNotNull(behandlingId = trygdetid.behandlingId, trygdetidId = trygdetid.id) }
 
-    fun oppdaterTrygdetid(oppdatertTrygdetid: Trygdetid): Trygdetid =
+    override fun oppdaterTrygdetid(oppdatertTrygdetid: Trygdetid): Trygdetid =
         dataSource
             .transaction { tx ->
                 val gjeldendeTrygdetid =
@@ -166,7 +166,7 @@ class TrygdetidRepository(
                 }
             }.let { hentTrygdetidMedIdNotNull(oppdatertTrygdetid.behandlingId, oppdatertTrygdetid.id) }
 
-    fun slettTrygdetid(trygdetidId: UUID) =
+    override fun slettTrygdetid(trygdetidId: UUID) {
         dataSource.transaction { tx ->
             queryOf(
                 statement =
@@ -181,8 +181,9 @@ class TrygdetidRepository(
                 tx.update(query)
             }
         }
+    }
 
-    fun hentTrygdetiderForAvdoede(avdoede: List<String>) =
+    override fun hentTrygdetiderForAvdoede(avdoede: List<String>) =
         using(sessionOf(dataSource)) { session ->
             session.run(
                 queryOf(

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepositoryKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepositoryKlient.kt
@@ -1,0 +1,172 @@
+package no.nav.etterlatte.trygdetid
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.michaelbull.result.mapBoth
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class TrygdetidRepositoryKlient(
+    config: Config,
+    httpClient: HttpClient,
+) : TrygdetidRepositoryOperasjoner {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+
+    private val clientId = config.getString("trygdetid.client.id")
+    private val resourceUrl = config.getString("trygdetid.resource.url")
+
+    private val baseUrl get() = "$resourceUrl/intern/trygdetid-crud"
+    private val systembruker = HardkodaSystembruker.river
+
+    override fun hentTrygdetidMedId(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+    ): Trygdetid? =
+        runBlocking {
+            try {
+                getOrNull("$baseUrl/behandling/$behandlingId/$trygdetidId")
+            } catch (e: Exception) {
+                throw TrygdetidRepositoryKlientException(
+                    "Hent trygdetid med id=$trygdetidId for behandling=$behandlingId feilet",
+                    e,
+                )
+            }
+        }
+
+    override fun hentTrygdetid(behandlingId: UUID): Trygdetid? = hentTrygdetiderForBehandling(behandlingId).minByOrNull { it.ident }
+
+    override fun hentTrygdetiderForBehandling(behandlingId: UUID): List<Trygdetid> =
+        runBlocking {
+            try {
+                get("$baseUrl/behandling/$behandlingId")
+            } catch (e: Exception) {
+                throw TrygdetidRepositoryKlientException(
+                    "Hent trygdetider for behandling=$behandlingId feilet",
+                    e,
+                )
+            }
+        }
+
+    override fun opprettTrygdetid(trygdetid: Trygdetid): Trygdetid =
+        runBlocking {
+            try {
+                logger.info("Oppretter trygdetid via klient for behandling=${trygdetid.behandlingId}")
+                post("$baseUrl/opprett", trygdetid)
+            } catch (e: Exception) {
+                throw TrygdetidRepositoryKlientException(
+                    "Opprett trygdetid feilet for behandling=${trygdetid.behandlingId}",
+                    e,
+                )
+            }
+        }
+
+    override fun oppdaterTrygdetid(oppdatertTrygdetid: Trygdetid): Trygdetid =
+        runBlocking {
+            try {
+                logger.info("Oppdaterer trygdetid via klient for behandling=${oppdatertTrygdetid.behandlingId}")
+                put("$baseUrl/oppdater", oppdatertTrygdetid)
+            } catch (e: Exception) {
+                throw TrygdetidRepositoryKlientException(
+                    "Oppdater trygdetid feilet for behandling=${oppdatertTrygdetid.behandlingId}",
+                    e,
+                )
+            }
+        }
+
+    override fun slettTrygdetid(trygdetidId: UUID) {
+        runBlocking {
+            try {
+                logger.info("Sletter trygdetid via klient med id=$trygdetidId")
+                delete("$baseUrl/$trygdetidId")
+            } catch (e: Exception) {
+                throw TrygdetidRepositoryKlientException("Slett trygdetid feilet for id=$trygdetidId", e)
+            }
+        }
+    }
+
+    override fun hentTrygdetiderForAvdoede(avdoede: List<String>): List<TrygdetidPartial> =
+        runBlocking {
+            try {
+                post("$baseUrl/avdoede", HentTrygdetiderForAvdoedeRequest(avdoede))
+            } catch (e: Exception) {
+                throw TrygdetidRepositoryKlientException("Hent trygdetider for avdøde feilet", e)
+            }
+        }
+
+    private suspend inline fun <reified T> get(url: String): T =
+        downstreamResourceClient
+            .get(
+                resource = Resource(clientId = clientId, url = url),
+                brukerTokenInfo = systembruker,
+            ).mapBoth(
+                success = { resource -> objectMapper.readValue(resource.response.toString()) },
+                failure = { errorResponse -> throw errorResponse },
+            )
+
+    private suspend inline fun <reified T : Any> getOrNull(url: String): T? =
+        try {
+            get(url)
+        } catch (e: ResponseException) {
+            if (e.response.status == HttpStatusCode.NotFound) null else throw e
+        }
+
+    private suspend inline fun <reified T> post(
+        url: String,
+        body: Any,
+    ): T =
+        downstreamResourceClient
+            .post(
+                resource = Resource(clientId = clientId, url = url),
+                brukerTokenInfo = systembruker,
+                postBody = body,
+            ).mapBoth(
+                success = { resource -> objectMapper.readValue(resource.response.toString()) },
+                failure = { errorResponse -> throw errorResponse },
+            )
+
+    private suspend inline fun <reified T> put(
+        url: String,
+        body: Any,
+    ): T =
+        downstreamResourceClient
+            .put(
+                resource = Resource(clientId = clientId, url = url),
+                brukerTokenInfo = systembruker,
+                putBody = body,
+            ).mapBoth(
+                success = { resource -> objectMapper.readValue(resource.response.toString()) },
+                failure = { errorResponse -> throw errorResponse },
+            )
+
+    private suspend fun delete(url: String) {
+        downstreamResourceClient
+            .delete(
+                resource = Resource(clientId = clientId, url = url),
+                brukerTokenInfo = systembruker,
+            ).mapBoth(
+                success = { },
+                failure = { errorResponse -> throw errorResponse },
+            )
+    }
+}
+
+data class HentTrygdetiderForAvdoedeRequest(
+    val avdoede: List<String>,
+)
+
+class TrygdetidRepositoryKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepositoryOperasjoner.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRepositoryOperasjoner.kt
@@ -1,0 +1,22 @@
+package no.nav.etterlatte.trygdetid
+
+import java.util.UUID
+
+interface TrygdetidRepositoryOperasjoner {
+    fun hentTrygdetidMedId(
+        behandlingId: UUID,
+        trygdetidId: UUID,
+    ): Trygdetid?
+
+    fun hentTrygdetid(behandlingId: UUID): Trygdetid?
+
+    fun hentTrygdetiderForBehandling(behandlingId: UUID): List<Trygdetid>
+
+    fun opprettTrygdetid(trygdetid: Trygdetid): Trygdetid
+
+    fun oppdaterTrygdetid(oppdatertTrygdetid: Trygdetid): Trygdetid
+
+    fun slettTrygdetid(trygdetidId: UUID)
+
+    fun hentTrygdetiderForAvdoede(avdoede: List<String>): List<TrygdetidPartial>
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidRoutes.kt
@@ -11,6 +11,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import io.ktor.server.routing.route
 import no.nav.etterlatte.behandling.BehandlingStatusService
+import no.nav.etterlatte.inTransactionIfNeeded
 import no.nav.etterlatte.libs.common.feilhaandtering.GenerellIkkeFunnetException
 import no.nav.etterlatte.libs.common.feilhaandtering.UgyldigForespoerselException
 import no.nav.etterlatte.libs.common.grunnlag.Grunnlagsopplysning
@@ -365,11 +366,13 @@ fun Route.trygdetid(
                                     beregnetTrygdetid,
                                 )
 
-                            behandlingsStatusService.settTrygdetidOppdatert(
-                                behandlingId = trygdetid.behandlingId,
-                                brukerTokenInfo = brukerTokenInfo,
-                                dryRun = false,
-                            )
+                            inTransactionIfNeeded {
+                                behandlingsStatusService.settTrygdetidOppdatert(
+                                    behandlingId = trygdetid.behandlingId,
+                                    brukerTokenInfo = brukerTokenInfo,
+                                    dryRun = false,
+                                )
+                            }
 
                             call.respond(
                                 trygdetidService

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -255,7 +255,7 @@ class TrygdetidServiceImpl(
             }
 
             val behandling =
-                behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
+                inTransactionIfNeeded { behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo) }
                     ?: throw GenerellIkkeFunnetException()
 
             when (behandling.behandlingType) {
@@ -433,7 +433,7 @@ class TrygdetidServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
     ): List<Trygdetid> {
         val behandling =
-            behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
+            inTransactionIfNeeded { behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo) }
                 ?: throw GenerellIkkeFunnetException()
         if (!behandling.status.kanEndres()) {
             throw UgyldigForespoerselException(
@@ -688,7 +688,7 @@ class TrygdetidServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
     ): List<Trygdetid> {
         val behandling =
-            behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
+            inTransactionIfNeeded { behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo) }
                 ?: throw GenerellIkkeFunnetException()
 
         logger.info("Kopierer trygdetid for behandling ${behandling.id} fra behandling $forrigeBehandlingId")
@@ -854,7 +854,7 @@ class TrygdetidServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
     ): Trygdetid {
         val behandling =
-            behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
+            inTransactionIfNeeded { behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo) }
                 ?: throw GenerellIkkeFunnetException()
 
         // Merk: vi kan ikke bruke den vanlige sjekken på kanOppdatereTrygdetid, siden dette kallet skjer typisk
@@ -1023,7 +1023,7 @@ class TrygdetidServiceImpl(
             throw IngenTrygdetidFunnetForAvdoede()
         }
         val behandling =
-            behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
+            inTransactionIfNeeded { behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo) }
                 ?: throw GenerellIkkeFunnetException()
         logger.info("Oppdaterer opplysningsgrunnlag for trygdetider (behandlingId=$behandlingId)")
 
@@ -1054,7 +1054,7 @@ class TrygdetidServiceImpl(
         kanOppdatereTrygdetid(behandlingId, brukerTokenInfo) {
             val trygdetider = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
             val behandling =
-                behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
+                inTransactionIfNeeded { behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo) }
                     ?: throw GenerellIkkeFunnetException()
 
             if (trygdetider.isEmpty()) {
@@ -1260,8 +1260,7 @@ class TrygdetidServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Boolean =
-        behandlingService
-            .hentDetaljertBehandling(behandlingId, brukerTokenInfo)
+        inTransactionIfNeeded { behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo) }
             ?.status in
             listOf(
                 IVERKSATT,

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -193,7 +193,7 @@ private fun TrygdetidPeriodePesys.fraPesystilVanlig(): TrygdetidPeriode =
 private const val AUTOMATISK_FREMTIDIG_BEGRUNNELSE = "Automatisk beregnet fremtidig trygdetid"
 
 class TrygdetidServiceImpl(
-    private val trygdetidRepository: TrygdetidRepository,
+    private val trygdetidRepository: TrygdetidRepositoryOperasjoner,
     private val behandlingService: BehandlingService,
     private val grunnlagService: GrunnlagService,
     private val beregnTrygdetidService: TrygdetidBeregningService,
@@ -201,19 +201,8 @@ class TrygdetidServiceImpl(
     private val avtaleService: AvtaleService,
     private val behandlingsStatusService: BehandlingStatusService,
     private val vedtaksvurderingKlient: VedtaksvurderingKlient,
-    private val brukInternTrygdetid: Boolean,
-    private val brukEgenDatabaseForTrygdetid: Boolean,
 ) : TrygdetidService {
     private val logger = LoggerFactory.getLogger(this::class.java)
-
-    private fun sjekkInternTrygdetidAktivert() {
-        if (!brukInternTrygdetid || !brukEgenDatabaseForTrygdetid) {
-            throw IkkeTillattException(
-                code = "INTERN_TRYGDETID_IKKE_AKTIVERT",
-                detail = "Intern trygdetid i behandling er ikke aktivert ennå",
-            )
-        }
-    }
 
     companion object {
         private const val SIST_FREMTIDIG_TRYGDETID_ALDER = 66L
@@ -222,24 +211,20 @@ class TrygdetidServiceImpl(
     override suspend fun hentTrygdetiderIBehandling(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): List<Trygdetid> {
-        sjekkInternTrygdetidAktivert()
-        return trygdetidRepository
+    ): List<Trygdetid> =
+        trygdetidRepository
             .hentTrygdetiderForBehandling(behandlingId)
             .mapNotNull { trygdetid -> sjekkTrygdetidMotGrunnlag(trygdetid, brukerTokenInfo) }
             .sortedBy { it.ident }
-    }
 
     override suspend fun hentTrygdetidIBehandlingMedId(
         behandlingId: UUID,
         trygdetidId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
-    ): Trygdetid? {
-        sjekkInternTrygdetidAktivert()
-        return trygdetidRepository
+    ): Trygdetid? =
+        trygdetidRepository
             .hentTrygdetidMedId(behandlingId, trygdetidId)
             ?.let { trygdetid -> sjekkTrygdetidMotGrunnlag(trygdetid, brukerTokenInfo) }
-    }
 
     override suspend fun opprettTrygdetiderForBehandling(
         behandlingId: UUID,
@@ -413,7 +398,6 @@ class TrygdetidServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): Boolean {
-        sjekkInternTrygdetidAktivert()
         val avdoede =
             grunnlagService.hentOpplysningsgrunnlag(behandlingId)?.hentAvdoede()
                 ?: throw InternfeilException("Grunnlag mangler for behandling $behandlingId")
@@ -447,7 +431,6 @@ class TrygdetidServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): List<Trygdetid> {
-        sjekkInternTrygdetidAktivert()
         val behandling =
             behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
                 ?: throw GenerellIkkeFunnetException()
@@ -703,7 +686,6 @@ class TrygdetidServiceImpl(
         forrigeBehandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): List<Trygdetid> {
-        sjekkInternTrygdetidAktivert()
         val behandling =
             behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
                 ?: throw GenerellIkkeFunnetException()
@@ -844,7 +826,6 @@ class TrygdetidServiceImpl(
         brukerTokenInfo: BrukerTokenInfo,
         block: suspend () -> T,
     ): T {
-        sjekkInternTrygdetidAktivert()
         val kanFastsetteTrygdetid =
             try {
                 behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = true)
@@ -869,7 +850,6 @@ class TrygdetidServiceImpl(
         overskriv: Boolean,
         brukerTokenInfo: BrukerTokenInfo,
     ): Trygdetid {
-        sjekkInternTrygdetidAktivert()
         val behandling =
             behandlingService.hentDetaljertBehandling(behandlingId, brukerTokenInfo)
                 ?: throw GenerellIkkeFunnetException()
@@ -1013,7 +993,6 @@ class TrygdetidServiceImpl(
         ident: String,
         beregnetTrygdetid: DetaljertBeregnetTrygdetidResultat,
     ): Trygdetid {
-        sjekkInternTrygdetidAktivert()
         val trygdetid =
             trygdetidRepository.hentTrygdetiderForBehandling(behandlingId).find { it.ident == ident }
                 ?: throw GenerellIkkeFunnetException()
@@ -1036,7 +1015,6 @@ class TrygdetidServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): List<Trygdetid> {
-        sjekkInternTrygdetidAktivert()
         val trygdetidList = trygdetidRepository.hentTrygdetiderForBehandling(behandlingId)
         if (trygdetidList.isEmpty()) {
             throw IngenTrygdetidFunnetForAvdoede()
@@ -1238,7 +1216,6 @@ class TrygdetidServiceImpl(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
     ): UUID? {
-        sjekkInternTrygdetidAktivert()
         val avdoede: List<Folkeregisteridentifikator> =
             grunnlagService
                 .hentOpplysningsgrunnlag(behandlingId)

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.etterlatte.behandling.BehandlingService
 import no.nav.etterlatte.behandling.BehandlingStatusService
 import no.nav.etterlatte.grunnlag.GrunnlagService
+import no.nav.etterlatte.inTransactionIfNeeded
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.ATTESTERT
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus.AVKORTET
@@ -296,7 +297,7 @@ class TrygdetidServiceImpl(
                     }
                 }
             }
-        }.also { behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false) }
+        }.also { inTransactionIfNeeded { behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false) } }
 
     private suspend fun opprettTrygdetiderForRevurdering(
         behandling: DetaljertBehandling,
@@ -712,7 +713,7 @@ class TrygdetidServiceImpl(
             if (!erOverstyrt && behandling.prosesstype != Prosesstype.AUTOMATISK) {
                 oppdaterBeregnetTrygdetid(behandlingId, trygdetid, brukerTokenInfo)
             } else {
-                behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false)
+                inTransactionIfNeeded { behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false) }
             }
         }
         return alleTrygdetider
@@ -828,7 +829,9 @@ class TrygdetidServiceImpl(
     ): T {
         val kanFastsetteTrygdetid =
             try {
-                behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = true)
+                inTransactionIfNeeded {
+                    behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = true)
+                }
                 true
             } catch (_: Exception) {
                 false
@@ -1065,7 +1068,7 @@ class TrygdetidServiceImpl(
             // Dersom forrige steg (vilkårsvurdering) har blitt endret vil statusen være VILKAARSVURDERT. Når man
             // trykker videre fra vilkårsvurdering skal denne validere tilstand og sette status TRYGDETID_OPPDATERT.
             if (behandling.status == BehandlingStatus.VILKAARSVURDERT) {
-                behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false)
+                inTransactionIfNeeded { behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false) }
                 true
             } else {
                 false
@@ -1189,7 +1192,7 @@ class TrygdetidServiceImpl(
             else -> trygdetid.oppdaterBeregnetTrygdetid(nyBeregnetTrygdetid)
         }.also { nyTrygdetid ->
             trygdetidRepository.oppdaterTrygdetid(nyTrygdetid)
-            behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false)
+            inTransactionIfNeeded { behandlingsStatusService.settTrygdetidOppdatert(behandlingId, brukerTokenInfo, dryRun = false) }
         }
     }
 

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
@@ -81,8 +81,8 @@ class AvtaleRepository(
             queryOf(
                 statement =
                     """
-                    INSERT INTO trygdeavtale(id, behandling_id, avtale_kode, avtale_dato_kode, avtale_kriteria_kode, arb_inntekt, arb_inntekt_kommentar, bereg_art, bereg_art_kommentar, nordisk_trygdeavtale, nordisk_trygdeavtale_kommentar, kilde)
-                    VALUES(:id, :behandlingId, :avtaleKode, :avtaleDatoKode, :avtaleKriteriaKode, :arbInntekt1G, :arbInntekt1GKommentar, :beregArt50, :beregArt50Kommentar, :nordiskTrygdeAvtale, :nordiskTrygdeAvtaleKommentar, :kilde)
+                    INSERT INTO trygdeavtale(id, behandling_id, avtale_kode, avtale_dato_kode, avtale_kriteria_kode, person_krets, arb_inntekt, arb_inntekt_kommentar, bereg_art, bereg_art_kommentar, nordisk_trygdeavtale, nordisk_trygdeavtale_kommentar, kilde)
+                    VALUES(:id, :behandlingId, :avtaleKode, :avtaleDatoKode, :avtaleKriteriaKode, :personKrets, :arbInntekt1G, :arbInntekt1GKommentar, :beregArt50, :beregArt50Kommentar, :nordiskTrygdeAvtale, :nordiskTrygdeAvtaleKommentar, :kilde)
                     """.trimIndent(),
                 paramMap =
                     mapOf(
@@ -97,7 +97,7 @@ class AvtaleRepository(
                         "beregArt50" to trygdeavtale.beregArt50?.name,
                         "beregArt50Kommentar" to trygdeavtale.beregArt50Kommentar,
                         "nordiskTrygdeAvtale" to trygdeavtale.nordiskTrygdeAvtale?.name,
-                        "nordiskTrygdeAvtaleKommentarto" to trygdeavtale.nordiskTrygdeAvtaleKommentar,
+                        "nordiskTrygdeAvtaleKommentar" to trygdeavtale.nordiskTrygdeAvtaleKommentar,
                         "kilde" to trygdeavtale.kilde.toJson(),
                     ),
             ).let { query ->

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
@@ -13,8 +13,8 @@ import javax.sql.DataSource
 
 class AvtaleRepository(
     private val dataSource: DataSource,
-) {
-    fun hentAvtale(behandlingId: UUID): Trygdeavtale? =
+) : AvtaleRepositoryOperasjoner {
+    override fun hentAvtale(behandlingId: UUID): Trygdeavtale? =
         using(sessionOf(dataSource)) { session ->
             queryOf(
                 statement =
@@ -34,7 +34,7 @@ class AvtaleRepository(
             }
         }
 
-    fun lagreAvtale(trygdeavtale: Trygdeavtale) {
+    override fun lagreAvtale(trygdeavtale: Trygdeavtale) {
         using(sessionOf(dataSource)) { session ->
             queryOf(
                 statement =
@@ -76,7 +76,7 @@ class AvtaleRepository(
         }
     }
 
-    fun opprettAvtale(trygdeavtale: Trygdeavtale) {
+    override fun opprettAvtale(trygdeavtale: Trygdeavtale) {
         using(sessionOf(dataSource)) { session ->
             queryOf(
                 statement =

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepositoryKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepositoryKlient.kt
@@ -1,0 +1,119 @@
+package no.nav.etterlatte.trygdetid.avtale
+
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.github.michaelbull.result.mapBoth
+import com.typesafe.config.Config
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.ResponseException
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.runBlocking
+import no.nav.etterlatte.libs.common.objectMapper
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.AzureAdClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.DownstreamResourceClient
+import no.nav.etterlatte.libs.ktor.ktor.ktorobo.Resource
+import no.nav.etterlatte.libs.ktor.token.HardkodaSystembruker
+import org.slf4j.LoggerFactory
+import java.util.UUID
+
+class AvtaleRepositoryKlient(
+    config: Config,
+    httpClient: HttpClient,
+) : AvtaleRepositoryOperasjoner {
+    private val logger = LoggerFactory.getLogger(this::class.java)
+
+    private val azureAdClient = AzureAdClient(config)
+    private val downstreamResourceClient = DownstreamResourceClient(azureAdClient, httpClient)
+
+    private val clientId = config.getString("trygdetid.client.id")
+    private val resourceUrl = config.getString("trygdetid.resource.url")
+
+    private val baseUrl get() = "$resourceUrl/intern/trygdetid-crud/avtale"
+    private val systembruker = HardkodaSystembruker.river
+
+    override fun hentAvtale(behandlingId: UUID): Trygdeavtale? =
+        runBlocking {
+            try {
+                getOrNull("$baseUrl/$behandlingId")
+            } catch (e: Exception) {
+                throw AvtaleRepositoryKlientException("Hent avtale for behandling=$behandlingId feilet", e)
+            }
+        }
+
+    override fun lagreAvtale(trygdeavtale: Trygdeavtale) {
+        runBlocking {
+            try {
+                logger.info("Lagrer avtale via klient for behandling=${trygdeavtale.behandlingId}")
+                put("$baseUrl/lagre", trygdeavtale)
+            } catch (e: Exception) {
+                throw AvtaleRepositoryKlientException(
+                    "Lagre avtale feilet for behandling=${trygdeavtale.behandlingId}",
+                    e,
+                )
+            }
+        }
+    }
+
+    override fun opprettAvtale(trygdeavtale: Trygdeavtale) {
+        runBlocking {
+            try {
+                logger.info("Oppretter avtale via klient for behandling=${trygdeavtale.behandlingId}")
+                post("$baseUrl/opprett", trygdeavtale)
+            } catch (e: Exception) {
+                throw AvtaleRepositoryKlientException(
+                    "Opprett avtale feilet for behandling=${trygdeavtale.behandlingId}",
+                    e,
+                )
+            }
+        }
+    }
+
+    private suspend inline fun <reified T : Any> getOrNull(url: String): T? =
+        try {
+            downstreamResourceClient
+                .get(
+                    resource = Resource(clientId = clientId, url = url),
+                    brukerTokenInfo = systembruker,
+                ).mapBoth(
+                    success = { resource -> objectMapper.readValue<T>(resource.response.toString()) },
+                    failure = { errorResponse -> throw errorResponse },
+                )
+        } catch (e: ResponseException) {
+            if (e.response.status == HttpStatusCode.NotFound) null else throw e
+        }
+
+    private suspend fun post(
+        url: String,
+        body: Any,
+    ) {
+        downstreamResourceClient
+            .post(
+                resource = Resource(clientId = clientId, url = url),
+                brukerTokenInfo = systembruker,
+                postBody = body,
+            ).mapBoth(
+                success = { },
+                failure = { errorResponse -> throw errorResponse },
+            )
+    }
+
+    private suspend fun put(
+        url: String,
+        body: Any,
+    ) {
+        downstreamResourceClient
+            .put(
+                resource = Resource(clientId = clientId, url = url),
+                brukerTokenInfo = systembruker,
+                putBody = body,
+            ).mapBoth(
+                success = { },
+                failure = { errorResponse -> throw errorResponse },
+            )
+    }
+}
+
+class AvtaleRepositoryKlientException(
+    override val message: String,
+    override val cause: Throwable,
+) : Exception(message, cause)

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepositoryOperasjoner.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleRepositoryOperasjoner.kt
@@ -1,0 +1,12 @@
+package no.nav.etterlatte.trygdetid.avtale
+
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import java.util.UUID
+
+interface AvtaleRepositoryOperasjoner {
+    fun hentAvtale(behandlingId: UUID): Trygdeavtale?
+
+    fun lagreAvtale(trygdeavtale: Trygdeavtale)
+
+    fun opprettAvtale(trygdeavtale: Trygdeavtale)
+}

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/avtale/AvtaleService.kt
@@ -1,7 +1,6 @@
 package no.nav.etterlatte.trygdetid.avtale
 
 import com.fasterxml.jackson.module.kotlin.readValue
-import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
 import no.nav.etterlatte.libs.common.objectMapper
 import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
 import no.nav.etterlatte.libs.common.trygdetid.avtale.TrygdetidAvtale
@@ -9,9 +8,7 @@ import no.nav.etterlatte.libs.common.trygdetid.avtale.TrygdetidAvtaleKriteria
 import java.util.UUID
 
 class AvtaleService(
-    private val avtaleRepository: AvtaleRepository,
-    private val brukInternTrygdetid: Boolean,
-    private val brukEgenDatabaseForTrygdetid: Boolean,
+    private val avtaleRepository: AvtaleRepositoryOperasjoner,
 ) {
     private var avtaler: List<TrygdetidAvtale>
     private var kriterier: List<TrygdetidAvtaleKriteria>
@@ -21,33 +18,15 @@ class AvtaleService(
         kriterier = loadJson("/trygdetid_avtale_kriterier.json")
     }
 
-    private fun sjekkInternTrygdetidAktivert() {
-        if (!brukInternTrygdetid || !brukEgenDatabaseForTrygdetid) {
-            throw IkkeTillattException(
-                code = "INTERN_TRYGDETID_IKKE_AKTIVERT",
-                detail = "Intern trygdetid i behandling er ikke aktivert ennå",
-            )
-        }
-    }
-
     fun hentAvtaler(): List<TrygdetidAvtale> = avtaler
 
     fun hentAvtaleKriterier(): List<TrygdetidAvtaleKriteria> = kriterier
 
-    fun hentAvtaleForBehandling(id: UUID): Trygdeavtale? {
-        sjekkInternTrygdetidAktivert()
-        return avtaleRepository.hentAvtale(id)
-    }
+    fun hentAvtaleForBehandling(id: UUID): Trygdeavtale? = avtaleRepository.hentAvtale(id)
 
-    fun lagreAvtale(trygdeavtale: Trygdeavtale) {
-        sjekkInternTrygdetidAktivert()
-        avtaleRepository.lagreAvtale(trygdeavtale)
-    }
+    fun lagreAvtale(trygdeavtale: Trygdeavtale) = avtaleRepository.lagreAvtale(trygdeavtale)
 
-    fun opprettAvtale(trygdeavtale: Trygdeavtale) {
-        sjekkInternTrygdetidAktivert()
-        avtaleRepository.opprettAvtale(trygdeavtale)
-    }
+    fun opprettAvtale(trygdeavtale: Trygdeavtale) = avtaleRepository.opprettAvtale(trygdeavtale)
 
     private inline fun <reified T> loadJson(filename: String) =
         this::class.java.getResource(filename)?.readText()?.let { json ->

--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/PesysKlient.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/klienter/PesysKlient.kt
@@ -92,7 +92,7 @@ class PesysKlientImpl(
                 resource =
                     Resource(
                         clientId = clientId,
-                        url = "$resourceUrl/api/uforetrygd/grunnlag/trygdetidsgrunnlagListeForLopendeUforetrygd",
+                        url = "$resourceUrl/pen/api/uforetrygd/grunnlag/trygdetidsgrunnlagListeForLopendeUforetrygd",
                     ),
                 brukerTokenInfo = brukerTokenInfo,
                 postBody = TrygdetidsgrunnlagRequest(avdoed.first, avdoed.second),
@@ -114,7 +114,7 @@ class PesysKlientImpl(
                 resource =
                     Resource(
                         clientId = clientId,
-                        url = "$resourceUrl/api/alderspensjon/grunnlag/trygdetidsgrunnlagListeForLopendeAlderspensjon",
+                        url = "$resourceUrl/pen/api/alderspensjon/grunnlag/trygdetidsgrunnlagListeForLopendeAlderspensjon",
                     ),
                 brukerTokenInfo = brukerTokenInfo,
                 postBody = TrygdetidsgrunnlagRequest(avdoed.first, avdoed.second),

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceIntegrationTest.kt
@@ -92,8 +92,6 @@ internal class TrygdetidServiceIntegrationTest(
                 avtaleService,
                 behandlingsStatusService,
                 vedtaksvurderingKlient,
-                brukInternTrygdetid = true,
-                brukEgenDatabaseForTrygdetid = true,
             )
     }
 

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -95,8 +95,6 @@ internal class TrygdetidServiceTest {
             avtaleService,
             behandlingsStatusService,
             vedtaksvurderingKlient,
-            brukInternTrygdetid = true,
-            brukEgenDatabaseForTrygdetid = true,
         )
 
     private fun trygdeavtale(behandlingId: UUID) =

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/avtale/AvtaleServiceTest.kt
@@ -25,8 +25,6 @@ internal class AvtaleServiceTest {
     private val service =
         AvtaleService(
             avtaleRepository = repository,
-            brukInternTrygdetid = true,
-            brukEgenDatabaseForTrygdetid = true,
         )
 
     @BeforeEach

--- a/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/dev.yaml
@@ -93,6 +93,8 @@ spec:
       value: api://dev-gcp.etterlatte.etterlatte-beregning/.default
     - name: TRYGDETID_API_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-trygdetid/.default
+    - name: BRUK_INTERN_TRYGDETID
+      value: "true"
     - name: PDLTJENESTER_API_SCOPE
       value: api://dev-gcp.etterlatte.etterlatte-pdltjenester/.default
     - name: UTBETALING_API_SCOPE

--- a/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
+++ b/apps/etterlatte-saksbehandling-ui/.nais/prod.yaml
@@ -93,6 +93,8 @@ spec:
       value: api://prod-gcp.etterlatte.etterlatte-beregning/.default
     - name: TRYGDETID_API_SCOPE
       value: api://prod-gcp.etterlatte.etterlatte-trygdetid/.default
+    - name: BRUK_INTERN_TRYGDETID
+      value: "false"
     - name: PDLTJENESTER_API_SCOPE
       value: api://prod-gcp.etterlatte.etterlatte-pdltjenester/.default
     - name: UTBETALING_API_SCOPE

--- a/apps/etterlatte-saksbehandling-ui/server/src/config/config.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/config/config.ts
@@ -106,6 +106,8 @@ const API_CONFIG_FROM_ENV = (): ApiConfig => {
 
 export const ApiConfig = hentApiConfigFraEnv()
 
+export const brukInternTrygdetid = process.env.BRUK_INTERN_TRYGDETID === 'true'
+
 export const ClientConfig = {
   gosysUrl: requireEnvValue('GOSYS_URL'),
   eessiPensjonUrl: requireEnvValue('EESSI_PENSJON_URL'),

--- a/apps/etterlatte-saksbehandling-ui/server/src/index.ts
+++ b/apps/etterlatte-saksbehandling-ui/server/src/index.ts
@@ -1,6 +1,6 @@
 import express, { NextFunction, Request, Response } from 'express'
 import path from 'path'
-import { ApiConfig, appConf, ClientConfig } from './config/config'
+import { ApiConfig, appConf, brukInternTrygdetid, ClientConfig } from './config/config'
 import { authenticateUser } from './middleware/auth'
 import { logger } from './monitoring/logger'
 import { tokenMiddleware } from './middleware/getOboToken'
@@ -102,7 +102,8 @@ app.use('/api/vedtak', tokenMiddleware(ApiConfig.behandling.scope), proxy(ApiCon
 
 app.use('/api/trygdetid', tokenMiddleware(ApiConfig.trygdetid.scope), proxy(ApiConfig.trygdetid.url))
 
-app.use('/api/trygdetid_v2', tokenMiddleware(ApiConfig.trygdetid.scope), proxy(ApiConfig.trygdetid.url))
+const trygdetidV2Config = brukInternTrygdetid ? ApiConfig.behandling : ApiConfig.trygdetid
+app.use('/api/trygdetid_v2', tokenMiddleware(trygdetidV2Config.scope), proxy(trygdetidV2Config.url))
 
 app.use('/api/utbetaling', tokenMiddleware(ApiConfig.utbetaling.scope), proxy(ApiConfig.utbetaling.url))
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/Application.kt
@@ -7,6 +7,7 @@ import no.nav.etterlatte.libs.ktor.initialisering.runEngine
 import no.nav.etterlatte.trygdetid.avtale.avtale
 import no.nav.etterlatte.trygdetid.config.ApplicationContext
 import no.nav.etterlatte.trygdetid.trygdetid
+import no.nav.etterlatte.trygdetid.trygdetidCrudRoute
 
 fun main() {
     ApplicationContext().let { Server(it).runServer() }
@@ -27,6 +28,7 @@ class Server(
             ) {
                 trygdetid(trygdetidService, behandlingKlient)
                 avtale(avtaleService, behandlingKlient)
+                trygdetidCrudRoute(trygdetidRepository, avtaleRepository)
             }
         }
 

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidCrudRoute.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidCrudRoute.kt
@@ -1,0 +1,88 @@
+package no.nav.etterlatte.trygdetid
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.request.receive
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.delete
+import io.ktor.server.routing.get
+import io.ktor.server.routing.post
+import io.ktor.server.routing.put
+import io.ktor.server.routing.route
+import no.nav.etterlatte.libs.common.trygdetid.avtale.Trygdeavtale
+import no.nav.etterlatte.trygdetid.avtale.AvtaleRepository
+import java.util.UUID
+
+data class HentTrygdetiderForAvdoedeRequest(
+    val avdoede: List<String>,
+)
+
+fun Route.trygdetidCrudRoute(
+    trygdetidRepository: TrygdetidRepository,
+    avtaleRepository: AvtaleRepository,
+) {
+    route("/intern/trygdetid-crud") {
+        route("/behandling/{behandlingId}") {
+            get {
+                val behandlingId = UUID.fromString(call.parameters["behandlingId"])
+                call.respond(trygdetidRepository.hentTrygdetiderForBehandling(behandlingId))
+            }
+
+            get("/{trygdetidId}") {
+                val behandlingId = UUID.fromString(call.parameters["behandlingId"])
+                val trygdetidId = UUID.fromString(call.parameters["trygdetidId"])
+                val trygdetid = trygdetidRepository.hentTrygdetidMedId(behandlingId, trygdetidId)
+                if (trygdetid != null) {
+                    call.respond(trygdetid)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+            }
+        }
+
+        post("/opprett") {
+            val trygdetid = call.receive<Trygdetid>()
+            call.respond(trygdetidRepository.opprettTrygdetid(trygdetid))
+        }
+
+        put("/oppdater") {
+            val trygdetid = call.receive<Trygdetid>()
+            call.respond(trygdetidRepository.oppdaterTrygdetid(trygdetid))
+        }
+
+        delete("/{trygdetidId}") {
+            val trygdetidId = UUID.fromString(call.parameters["trygdetidId"])
+            trygdetidRepository.slettTrygdetid(trygdetidId)
+            call.respond(HttpStatusCode.NoContent)
+        }
+
+        post("/avdoede") {
+            val request = call.receive<HentTrygdetiderForAvdoedeRequest>()
+            call.respond(trygdetidRepository.hentTrygdetiderForAvdoede(request.avdoede))
+        }
+
+        route("/avtale") {
+            get("/{behandlingId}") {
+                val behandlingId = UUID.fromString(call.parameters["behandlingId"])
+                val avtale = avtaleRepository.hentAvtale(behandlingId)
+                if (avtale != null) {
+                    call.respond(avtale)
+                } else {
+                    call.respond(HttpStatusCode.NotFound)
+                }
+            }
+
+            post("/opprett") {
+                val trygdeavtale = call.receive<Trygdeavtale>()
+                avtaleRepository.opprettAvtale(trygdeavtale)
+                call.respond(HttpStatusCode.Created)
+            }
+
+            put("/lagre") {
+                val trygdeavtale = call.receive<Trygdeavtale>()
+                avtaleRepository.lagreAvtale(trygdeavtale)
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+    }
+}

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidRepository.kt
@@ -162,7 +162,7 @@ class TrygdetidRepository(
                         tx,
                     )
                 } else {
-                    nullstillBeregnetTrygdetid(oppdatertTrygdetid.behandlingId, tx)
+                    nullstillBeregnetTrygdetid(oppdatertTrygdetid.behandlingId, oppdatertTrygdetid.id, tx)
                 }
             }.let { hentTrygdetidMedIdNotNull(oppdatertTrygdetid.behandlingId, oppdatertTrygdetid.id) }
 
@@ -534,6 +534,7 @@ class TrygdetidRepository(
 
     private fun nullstillBeregnetTrygdetid(
         behandlingId: UUID,
+        trygdetidId: UUID,
         tx: TransactionalSession,
     ) = queryOf(
         statement =
@@ -561,9 +562,9 @@ class TrygdetidRepository(
                 beregnet_trygdetid_overstyrt = false,
                 yrkesskade = false,
                 overstyrt_begrunnelse = null
-            WHERE behandling_id = :behandlingId
+            WHERE behandling_id = :behandlingId AND id = :trygdetidId
             """.trimIndent(),
-        paramMap = mapOf("behandlingId" to behandlingId),
+        paramMap = mapOf("behandlingId" to behandlingId, "trygdetidId" to trygdetidId),
     ).let { query -> tx.update(query) }
 
     private fun hentTrygdetidGrunnlag(trygdetidId: UUID): List<TrygdetidGrunnlag> =

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/avtale/AvtaleRepository.kt
@@ -81,8 +81,8 @@ class AvtaleRepository(
             queryOf(
                 statement =
                     """
-                    INSERT INTO trygdeavtale(id, behandling_id, avtale_kode, avtale_dato_kode, avtale_kriteria_kode, arb_inntekt, arb_inntekt_kommentar, bereg_art, bereg_art_kommentar, nordisk_trygdeavtale, nordisk_trygdeavtale_kommentar, kilde)
-                    VALUES(:id, :behandlingId, :avtaleKode, :avtaleDatoKode, :avtaleKriteriaKode, :arbInntekt1G, :arbInntekt1GKommentar, :beregArt50, :beregArt50Kommentar, :nordiskTrygdeAvtale, :nordiskTrygdeAvtaleKommentar, :kilde)
+                    INSERT INTO trygdeavtale(id, behandling_id, avtale_kode, avtale_dato_kode, avtale_kriteria_kode, person_krets, arb_inntekt, arb_inntekt_kommentar, bereg_art, bereg_art_kommentar, nordisk_trygdeavtale, nordisk_trygdeavtale_kommentar, kilde)
+                    VALUES(:id, :behandlingId, :avtaleKode, :avtaleDatoKode, :avtaleKriteriaKode, :personKrets, :arbInntekt1G, :arbInntekt1GKommentar, :beregArt50, :beregArt50Kommentar, :nordiskTrygdeAvtale, :nordiskTrygdeAvtaleKommentar, :kilde)
                     """.trimIndent(),
                 paramMap =
                     mapOf(
@@ -97,7 +97,7 @@ class AvtaleRepository(
                         "beregArt50" to trygdeavtale.beregArt50?.name,
                         "beregArt50Kommentar" to trygdeavtale.beregArt50Kommentar,
                         "nordiskTrygdeAvtale" to trygdeavtale.nordiskTrygdeAvtale?.name,
-                        "nordiskTrygdeAvtaleKommentarto" to trygdeavtale.nordiskTrygdeAvtaleKommentar,
+                        "nordiskTrygdeAvtaleKommentar" to trygdeavtale.nordiskTrygdeAvtaleKommentar,
                         "kilde" to trygdeavtale.kilde.toJson(),
                     ),
             ).let { query ->

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/config/ApplicationContext.kt
@@ -29,7 +29,7 @@ class ApplicationContext {
             password = properties.dbPassword,
         )
     private val grunnlagKlient = GrunnlagKlient(config, httpClient())
-    private val avtaleRepository = AvtaleRepository(dataSource)
+    val avtaleRepository = AvtaleRepository(dataSource)
 
     val behandlingKlient = BehandlingKlient(config, httpClient())
     val avtaleService = AvtaleService(avtaleRepository)
@@ -37,7 +37,7 @@ class ApplicationContext {
     val vedtaksvurderingKlient = VedtaksvurderingBehandlingKlient(config, httpClient())
 
     val featureToggleService = FeatureToggleService.initialiser(featureToggleProperties(config))
-    private val trygdetidRepository = TrygdetidRepository(dataSource)
+    val trygdetidRepository = TrygdetidRepository(dataSource)
 
     val trygdetidService =
         TrygdetidServiceImpl(


### PR DESCRIPTION
Trygdetid-migrering: CRUD-lag og transaksjonsfiks

Første steg i migreringen av trygdetid-logikk inn i etterlatte-behandling. Målet er å la behandling eie service-logikken mens persistering midlertidig fortsatt skjer via etterlatte-trygdetid, frem til behandling får egen DB-tabell.

Hva er gjort

CRUD-lag i etterlatte-trygdetid

 - Lagt til /intern/trygdetid-crud med dedikerte interne endepunkter for create/update/delete — skilt fra de eksisterende lese-endepunktene.

Repository-abstraksjon i etterlatte-behandling

 - TrygdetidRepositoryOperasjoner og AvtaleRepositoryOperasjoner — nye interfaces
 - TrygdetidRepository og AvtaleRepository implementerer disse interfacene (override)
 - TrygdetidRepositoryKlient og AvtaleRepositoryKlient — REST-klienter som kaller trygdetid sine CRUD-endepunkter
 - ServiceModule velger implementasjon basert på BRUK_EGEN_DATABASE_FOR_TRYGDETID (false → REST-klient, true → egen DB)
 - Toggle-sjekker fjernet fra service-metodene selv

Transaksjonshåndtering

 - Innfører inTransactionIfNeeded {} i Contekst.kt — åpner transaksjon kun når Kontekst er satt og ingen transaksjon er aktiv. Trygt for tester (ingen Kontekst) og nøstede kall (allerede i transaksjon).
 - settTrygdetidOppdatert og hentDetaljertBehandling-kall i TrygdetidService og TrygdetidRoutes er wrappet med denne.

Konfigurasjon

 - dev.yaml og prod.yaml: BRUK_INTERN_TRYGDETID=true, BRUK_EIGEN_DATABASE=false — ruter via behandling sin service, skriver til trygdetid sin DB via REST.
 - PEN_URL — PesysKlient legger selv på /api-prefix, som ga dobbelt /api/api/-sti og 403 fra PEN.

Frontend

 - UI peker mot /api/trygdetid_v2 (behandling) i stedet for det gamle endepunktet.

Hva er ikke gjort ennå

 - Behandling har ikke sin egen DB-tabell for trygdetid ennå — det kommer i neste steg.
 - BRUK_EGEN_DATABASE_FOR_TRYGDETID=false i prod inntil vider