### PR TITLE
Lukker perioden for årsoppgjør ved sanksjon over flere år

### DIFF
--- a/.github/lessons.md
+++ b/.github/lessons.md
@@ -61,3 +61,11 @@
 **2026-06-12 — Implementasjon vs. test-kontrakten**
 - Observation: Ny implementasjon konsoliderte to `hentGrunnlag`-kall til ett, men testene forventet `exactly = 2`. Dette var en korrekt forbedring, men det krevde oppdatering av testpåstander som ikke var åpenbare i forkant.
 - Action: Ved refaktorering fra HTTP-klient til intern service: tell forventede kall i den NYE impl., ikke den gamle. Den nye kan optimalisere (f.eks. cache grunnlag lokalt i scope) — sjekk om `exactly = N` i testene reflekterer ny eller gammel oppførsel.
+
+**2026-06-15 — Feilsøking / valideringslogikk**
+- Observation: Jeg gikk mange runder med å spore hele avkortingsflyten manuelt uten å zoome inn på den konkrete feilmeldingen brukeren ville fått. Det hadde spart mange iterasjoner å se etter `throw`-statements i valideringslogikken med en gang.
+- Action: Ved feilsøking av valideringsfeil: finn alle `throw`-statements i den relevante koden først, og sjekk hvilke betingelser som trigger dem for scenariet brukeren beskriver — ikke spor hele flyten line-by-line fra topp til bunn.
+
+**2026-06-15 — Feilsøking / loopstopp**
+- Observation: Jeg fortsatte å lese kode i loop uten å gjenskape feilen — og kjente igjen at jeg ikke klarte å finne rotårsaken, men fortsatte likevel i stedet for å stoppe og spørre.
+- Action: Hvis samme problem er undersøkt 3+ ganger uten at feilen er gjenskapt eller rootcause funnet: bryt ut, oppsummer hva som er utelukket, og spør brukeren om mer kontekst (eksakt feilmelding, steg for å reprodusere, logg-output).

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -145,7 +145,10 @@ data class Avkorting(
                                                         ),
                                                     maanederInnvilget =
                                                         inntektsavkorting.grunnlag.maanederInnvilget
-                                                            ?: fallbackMaanederInnvilget(inntektsavkorting, aarsoppgjoerFom),
+                                                            ?: fallbackMaanederInnvilget(
+                                                                inntektsavkorting,
+                                                                aarsoppgjoerFom,
+                                                            ),
                                                 ),
                                             avkortingsperioder =
                                                 if (nullstillAvkortetYtelse) {
@@ -582,7 +585,9 @@ data class Avkorting(
                 )
             } else {
                 reberegnetInntektsavkorting.first().let {
-                    val tomSluttenAvAaret = tomSluttenAvAaretForAvkortetYtelse(aarsoppgjoer, opphoerFom)
+                    val tomSluttenAvAaret =
+                        tomSluttenAvAaretForAvkortetYtelse(aarsoppgjoer, ytelseFoerAvkorting, opphoerFom)
+
                     val sistePeriode =
                         when (val tomForPeriode = it.grunnlag.periode.tom) {
                             null -> {
@@ -639,7 +644,7 @@ data class Avkorting(
                 .sortedBy { it.fom }
         val avkortetYtelseMedAllForventetInntekt = mutableListOf<AvkortetYtelse>()
 
-        val tomSluttenAvAaret = tomSluttenAvAaretForAvkortetYtelse(aarsoppgjoer, opphoerFom)
+        val tomSluttenAvAaret = tomSluttenAvAaretForAvkortetYtelse(aarsoppgjoer, ytelseFoerAvkorting, opphoerFom)
 
         reberegnetInntektsavkorting.forEachIndexed { i, inntektsavkorting ->
             // Kun de sanksjonene som er lagt inn fom < denne inntektsavkortingen er tidligere beregnet med
@@ -749,6 +754,7 @@ data class Avkorting(
      */
     private fun tomSluttenAvAaretForAvkortetYtelse(
         aarsoppgjoer: AarsoppgjoerLoepende,
+        ytelseFoerAvkorting: List<YtelseFoerAvkorting>,
         opphoerFom: YearMonth?,
     ): YearMonth? {
         val harAaroppgjoerNesteAaar =
@@ -767,7 +773,19 @@ data class Avkorting(
                 if (opphoerFom != null && opphoerFom.minusMonths(1).year == aarsoppgjoer.aar) {
                     opphoerFom.minusMonths(1)
                 } else {
-                    null
+                    // Har vi beregning som krysser året uten et neste årsoppgjør må vi lukke dette året.
+                    // Dette er kun trygt å gjøre hvis vi beregner 0 for denne perioden
+                    val harBeregningSenereEnnDetteAarsoppgjoer =
+                        ytelseFoerAvkorting.any { ytelse ->
+                            val tom = ytelse.periode.tom
+                            ytelse.periode.fom.year == aarsoppgjoer.aar && tom != null && tom.year > aarsoppgjoer.aar &&
+                                ytelse.beregning == 0
+                        }
+                    if (harBeregningSenereEnnDetteAarsoppgjoer) {
+                        YearMonth.of(aarsoppgjoer.aar, 12)
+                    } else {
+                        null
+                    }
                 }
             }
         }

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -613,11 +613,56 @@ data class Avkorting(
                 }
             }
 
+        val avkortetYtelseJustert =
+            aapneSistePeriodeHvisBeregningErAapen(avkortetYtelse, aarsoppgjoer, ytelseFoerAvkorting, opphoerFom)
+
         return aarsoppgjoer.copy(
             ytelseFoerAvkorting = ytelseFoerAvkorting,
             inntektsavkorting = reberegnetInntektsavkorting,
-            avkortetYtelse = avkortetYtelse,
+            avkortetYtelse = avkortetYtelseJustert,
         )
+    }
+
+    /**
+     * Hvis dette er det siste årsoppgjøret og den underliggende beregningen har åpen TOM (f.eks. permanent stans),
+     * skal siste periode i avkortet ytelse også ha åpen TOM. Beregningen kjøres trygt med lukket periode
+     * (tom=desember) for å unngå problemer i regelkjøringen, og siste periode åpnes i etterkant.
+     */
+    private fun aapneSistePeriodeHvisBeregningErAapen(
+        avkortetYtelse: List<AvkortetYtelse>,
+        aarsoppgjoer: AarsoppgjoerLoepende,
+        ytelseFoerAvkorting: List<YtelseFoerAvkorting>,
+        opphoerFom: YearMonth?,
+    ): List<AvkortetYtelse> {
+        if (avkortetYtelse.isEmpty()) {
+            return avkortetYtelse
+        }
+        val harAarsoppgjoerNesteAar = this.aarsoppgjoer.any { it.aar == aarsoppgjoer.aar + 1 }
+        if (harAarsoppgjoerNesteAar) {
+            return avkortetYtelse
+        }
+        if (opphoerFom != null) {
+            return avkortetYtelse
+        }
+        val sisteBeregning = ytelseFoerAvkorting.maxByOrNull { it.periode.fom } ?: return avkortetYtelse
+        if (sisteBeregning.periode.tom != null) {
+            return avkortetYtelse
+        }
+        val harBeregningsperioderSomIkkeErNullEtterSisteAarsoppgjoeret =
+            ytelseFoerAvkorting.any {
+                it.beregning != 0 && it.periode.fom.year > aarsoppgjoer.aar
+            }
+        if (harBeregningsperioderSomIkkeErNullEtterSisteAarsoppgjoeret) {
+            throw InternfeilException(
+                "Vi har ikke nok grunnlag for å beregne avkortingen for årsoppgjør ${aarsoppgjoer.id}, " +
+                    "siden vi har en åpen beregningsperiode med fom > det siste årsoppgjøret vi har grunnlag for, " +
+                    "med en beregning som ikke er 0 kr. Dette betyr at vi har ytelse som skal avkortes som ikke " +
+                    "blir det, avbryter derfor beregning av avkorting. " +
+                    "${ytelseFoerAvkorting.joinToString { "${it.periode to it.beregningsreferanse}" }}",
+            )
+        }
+        val sistePeriode = avkortetYtelse.last()
+        return avkortetYtelse.dropLast(1) + sistePeriode.copy(periode = sistePeriode.periode.copy(tom = null))
     }
 
     /**

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingNyeReglerTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingNyeReglerTest.kt
@@ -1,6 +1,8 @@
 package no.nav.etterlatte.beregning.regler.avkorting
 
 import io.kotest.assertions.asClue
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.collections.shouldNotBeEmpty
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
 import io.kotest.matchers.shouldBe
 import io.mockk.every
@@ -58,6 +60,65 @@ class BeregnAvkortingNyeReglerTest {
     @AfterEach
     fun `unmock grunnbeloep`() {
         unmockkObject(GrunnbeloepRepository)
+    }
+
+    @Test
+    fun `Foerstegangsbehandling med aapen STANS fra november beregner avkorting med kun 2024-inntekt`() {
+        val avkorting =
+            Avkorting()
+                .beregnAvkortingMedNyeGrunnlag(
+                    nyttGrunnlag =
+                        listOf(
+                            avkortinggrunnlagLagreDto(
+                                aarsinntekt = 300_000,
+                                fratrekkInnAar = 0,
+                                fom = YearMonth.of(2024, Month.FEBRUARY),
+                            ),
+                        ),
+                    bruker = bruker,
+                    beregning =
+                        beregning(
+                            beregninger =
+                                listOf(
+                                    beregningsperiode(
+                                        datoFOM = YearMonth.of(2024, Month.FEBRUARY),
+                                        datoTOM = YearMonth.of(2024, Month.OCTOBER),
+                                        utbetaltBeloep = 15_000,
+                                    ),
+                                    beregningsperiode(
+                                        datoFOM = YearMonth.of(2024, Month.NOVEMBER),
+                                        datoTOM = YearMonth.of(2025, Month.APRIL),
+                                        utbetaltBeloep = 0, // STANS
+                                    ),
+                                    beregningsperiode(
+                                        datoFOM = YearMonth.of(2025, Month.MAY),
+                                        datoTOM = YearMonth.of(2026, Month.APRIL),
+                                        utbetaltBeloep = 0, // STANS
+                                    ),
+                                    beregningsperiode(
+                                        datoFOM = YearMonth.of(2026, Month.MAY),
+                                        datoTOM = null,
+                                        utbetaltBeloep = 0, // STANS
+                                    ),
+                                ),
+                        ),
+                    sanksjoner =
+                        listOf(
+                            sanksjon(
+                                fom = YearMonth.of(2024, Month.NOVEMBER),
+                                tom = null,
+                                type = SanksjonType.STANS,
+                            ),
+                        ),
+                    opphoerFom = null,
+                    brukNyeReglerAvkorting = true,
+                )
+        avkorting.aarsoppgjoer shouldHaveSize 1
+        avkorting.aarsoppgjoer.single().aar shouldBe 2024
+        avkorting.aarsoppgjoer
+            .single()
+            .avkortetYtelse
+            .shouldNotBeEmpty()
     }
 
     @Test

--- a/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingNyeReglerTest.kt
+++ b/apps/etterlatte-beregning/src/test/kotlin/avkorting/BeregnAvkortingNyeReglerTest.kt
@@ -115,10 +115,9 @@ class BeregnAvkortingNyeReglerTest {
                 )
         avkorting.aarsoppgjoer shouldHaveSize 1
         avkorting.aarsoppgjoer.single().aar shouldBe 2024
-        avkorting.aarsoppgjoer
-            .single()
-            .avkortetYtelse
-            .shouldNotBeEmpty()
+        val avkortetYtelse = avkorting.aarsoppgjoer.single().avkortetYtelse
+        avkortetYtelse.shouldNotBeEmpty()
+        avkortetYtelse.last().periode.tom shouldBe null
     }
 
     @Test


### PR DESCRIPTION
Vi har problemer med å beregne avkortinger for år som er totalt nullet ut med sanksjoner i dag -- denne endringen gjør at vi tillater den siste avkortingsperioden å løpe utover som 0, så lenge det ikke er et opphør senere / beregnet mer enn 0 senere. 

Dette skal gi "like" vedtak til oppdrag, og samtidig ikke steile på å beregne saker litt komplisert, som vi har behov for å gjøre med litt rare saker i produksjon.