### PR TITLE
Vil sette harInstitusjonsopphold til false dersom vi får en feil når …

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -495,7 +495,7 @@ class EtteroppgjoerService(
                 beregningKlient.hentBeregningsgrunnlag(behandlingId, HardkodaSystembruker.etteroppgjoer)
             } catch (e: Exception) {
                 logger.warn(
-                    "Behandling ($behandlingId) har ikke beregningsgrunnlag. Kan returnere false da harInstitusjonsopphold på Etteroppgjør ikke lenger er i bruk.",
+                    "Behandling ($behandlingId) har ikke beregningsgrunnlag. Kan returnere false da harInstitusjonsopphold på Etteroppgjør ikke lenger er i bruk.", e
                 )
                 return false
             }

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/etteroppgjoer/EtteroppgjoerService.kt
@@ -23,7 +23,6 @@ import no.nav.etterlatte.behandling.klienter.BeregningKlient
 import no.nav.etterlatte.behandling.klienter.VedtakInternalService
 import no.nav.etterlatte.libs.common.behandling.SakType
 import no.nav.etterlatte.libs.common.behandling.UtlandstilknytningType
-import no.nav.etterlatte.libs.common.behandling.etteroppgjoer.EtteroppgjoerFilter
 import no.nav.etterlatte.libs.common.behandling.etteroppgjoer.EtteroppgjoerHendelser
 import no.nav.etterlatte.libs.common.beregning.EtteroppgjoerResultatType
 import no.nav.etterlatte.libs.common.feilhaandtering.IkkeTillattException
@@ -492,7 +491,14 @@ class EtteroppgjoerService(
         inntektsaar: Int,
     ): Boolean {
         val beregningsGrunnlag =
-            beregningKlient.hentBeregningsgrunnlag(behandlingId, HardkodaSystembruker.etteroppgjoer)
+            try {
+                beregningKlient.hentBeregningsgrunnlag(behandlingId, HardkodaSystembruker.etteroppgjoer)
+            } catch (e: Exception) {
+                logger.warn(
+                    "Behandling ($behandlingId) har ikke beregningsgrunnlag. Kan returnere false da harInstitusjonsopphold på Etteroppgjør ikke lenger er i bruk.",
+                )
+                return false
+            }
         return beregningsGrunnlag.institusjonsopphold.any {
             it.fom.year <= inntektsaar && (it.tom?.year ?: inntektsaar) >= inntektsaar
         }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/etteroppgjoer/EtteroppgjoerServiceTest.kt
@@ -383,6 +383,22 @@ class EtteroppgjoerServiceTest {
     }
 
     @Test
+    fun `Setter harInstitusjonsopphold = false dersom vi får feil når vi henter beregningsgrunnlag`() {
+        val ctx = TestContext(sakId)
+        every { ctx.dao.hentEtteroppgjoerForInntektsaar(sakId, 2024) } returns
+            null
+
+        coEvery { ctx.beregningKlient.hentBeregningsgrunnlag(any(), any()) } throws (Exception())
+
+        val resultat = runBlocking { ctx.service.opprettNyttEtteroppgjoer(sakId, 2024) }
+
+        with(resultat) {
+            this.harInstitusjonsopphold shouldBe false
+        }
+        coVerify(exactly = 1) { ctx.dao.lagreEtteroppgjoer(any()) }
+    }
+
+    @Test
     fun `opprettEtteroppgjoer oppdaterer etteroppgjør men ikke status dersom behandling ikke er påbegynt`() {
         val ctx = TestContext(sakId)
         every { ctx.dao.hentEtteroppgjoerForInntektsaar(sakId, 2024) } returns


### PR DESCRIPTION
…vi prøver å hente beregningsgrunnlag for å utlede dette. Dette kan gjøres da denne koden ikke lenger er i bruk.

Etter feil i prod ved skattehendelse: 


x_correlation_id | f4278d5b-4e1d-4792-81fd-0003ea1e25f1

Caused by: com.fasterxml.jackson.databind.RuntimeJsonMappingException: Deserialized value did not match the specified type; specified no.nav.etterlatte.beregning.grunnlag.BeregningsGrunnlag(non-null) but was null
	at no.nav.etterlatte.behandling.klienter.BeregningKlientImpl.hentBeregningsgrunnlag(BeregningKlientImpl.kt:549)
	(...)


Opprettet oppgave for å rydde opp i død kode: 
https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-29735