### PR TITLE
Legger på validering av begrunnelsesfeltet for trygdetid

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -1084,6 +1084,10 @@ class TrygdetidServiceImpl(
                 throw TrygdetidManglerBeregning()
             }
 
+            if (trygdetider.any { it.begrunnelse == null }) {
+                throw TrygdetidManglerBegrunnelse()
+            }
+
             // Dersom forrige steg (vilkårsvurdering) har blitt endret vil statusen være VILKAARSVURDERT. Når man
             // trykker videre fra vilkårsvurdering skal denne validere tilstand og sette status TRYGDETID_OPPDATERT.
             if (behandling.status == BehandlingStatus.VILKAARSVURDERT) {
@@ -1352,6 +1356,12 @@ class TrygdetidManglerBeregning :
     UgyldigForespoerselException(
         code = "TRYGDETID_MANGLER_BEREGNING",
         detail = "Oppgitt trygdetid er ikke gyldig fordi det mangler en beregning",
+    )
+
+class TrygdetidManglerBegrunnelse :
+    UgyldigForespoerselException(
+        code = "TRYGDETID_MANGLER_BEGRUNNELSE",
+        detail = "Oppgitt trygdetid må ha begrunnelse satt for å kunne gå videre",
     )
 
 class IngenFoedselsdatoForAvdoedFunnet(

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
@@ -75,6 +75,7 @@ fun trygdetid(
     yrkesskade: Boolean = false,
     overstyrtNorskPoengaar: Int? = null,
     opplysningerDifferanse: OpplysningerDifferanse = OpplysningerDifferanse(false, GrunnlagOpplysningerDto.tomt()),
+    begrunnelse: String? = null,
 ) = Trygdetid(
     id = randomUUID(),
     sakId = sakId,
@@ -86,6 +87,7 @@ fun trygdetid(
     yrkesskade = yrkesskade,
     opplysningerDifferanse = opplysningerDifferanse,
     overstyrtNorskPoengaar = overstyrtNorskPoengaar,
+    begrunnelse = begrunnelse,
 )
 
 fun standardOpplysningsgrunnlag(): List<Opplysningsgrunnlag> {

--- a/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -1578,7 +1578,12 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal sjekke gyldighet og oppdatere status hvis behandlingstatus er VILKAARSVURDERT`() {
         val behandlingId = randomUUID()
-        val eksisterendeTrygdetid = trygdetid(behandlingId, beregnetTrygdetid = beregnetTrygdetid())
+        val eksisterendeTrygdetid =
+            trygdetid(
+                behandlingId = behandlingId,
+                beregnetTrygdetid = beregnetTrygdetid(),
+                begrunnelse = "Begrunnelse for trygdetid",
+            )
 
         every { behandlingService.hentDetaljertBehandling(any(), any()) } returns
             behandling(behandlingId, behandlingStatus = BehandlingStatus.VILKAARSVURDERT)

--- a/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
+++ b/apps/etterlatte-trygdetid/src/main/kotlin/trygdetid/TrygdetidService.kt
@@ -1036,6 +1036,10 @@ class TrygdetidServiceImpl(
                 throw TrygdetidManglerBeregning()
             }
 
+            if (trygdetider.any { it.begrunnelse == null }) {
+                throw TrygdetidManglerBegrunnelse()
+            }
+
             // Dersom forrige steg (vilkårsvurdering) har blitt endret vil statusen være VILKAARSVURDERT. Når man
             // trykker videre fra vilkårsvurdering skal denne validere tilstand og sette status TRYGDETID_OPPDATERT.
             if (behandling.status == BehandlingStatus.VILKAARSVURDERT) {
@@ -1298,6 +1302,12 @@ class TrygdetidManglerBeregning :
     UgyldigForespoerselException(
         code = "TRYGDETID_MANGLER_BEREGNING",
         detail = "Oppgitt trygdetid er ikke gyldig fordi det mangler en beregning",
+    )
+
+class TrygdetidManglerBegrunnelse :
+    UgyldigForespoerselException(
+        code = "TRYGDETID_MANGLER_BEGRUNNELSE",
+        detail = "Oppgitt trygdetid må ha begrunnelse satt for å kunne gå videre",
     )
 
 class IngenFoedselsdatoForAvdoedFunnet(

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TestHelper.kt
@@ -75,6 +75,7 @@ fun trygdetid(
     yrkesskade: Boolean = false,
     overstyrtNorskPoengaar: Int? = null,
     opplysningerDifferanse: OpplysningerDifferanse = OpplysningerDifferanse(false, GrunnlagOpplysningerDto.tomt()),
+    begrunnelse: String? = null,
 ) = Trygdetid(
     id = randomUUID(),
     sakId = sakId,
@@ -86,6 +87,7 @@ fun trygdetid(
     yrkesskade = yrkesskade,
     opplysningerDifferanse = opplysningerDifferanse,
     overstyrtNorskPoengaar = overstyrtNorskPoengaar,
+    begrunnelse = begrunnelse,
 )
 
 fun standardOpplysningsgrunnlag(): List<Opplysningsgrunnlag> {

--- a/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
+++ b/apps/etterlatte-trygdetid/src/test/kotlin/no/nav/etterlatte/trygdetid/TrygdetidServiceTest.kt
@@ -1586,7 +1586,12 @@ internal class TrygdetidServiceTest {
     @Test
     fun `skal sjekke gyldighet og oppdatere status hvis behandlingstatus er VILKAARSVURDERT`() {
         val behandlingId = randomUUID()
-        val eksisterendeTrygdetid = trygdetid(behandlingId, beregnetTrygdetid = beregnetTrygdetid())
+        val eksisterendeTrygdetid =
+            trygdetid(
+                behandlingId = behandlingId,
+                beregnetTrygdetid = beregnetTrygdetid(),
+                begrunnelse = "Begrunnelse for trygdetid",
+            )
 
         coEvery { behandlingKlient.hentBehandling(any(), any()) } returns
             behandling(behandlingId, behandlingStatus = BehandlingStatus.VILKAARSVURDERT)


### PR DESCRIPTION
Begrunnelsesfeltet i trygdetidsbildet skal nå være obligatorisk i en behandling.

Det er altså snakk om denne begrunnelsen:
<img width="313" height="151" alt="image" src="https://github.com/user-attachments/assets/9825da04-54b5-408b-88b6-e6e65f69ad6d" />
