### PR TITLE
Vi må oppdatere payload for vedlegg i DB selv om det er en tom liste

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/brev/BrevKlientImpl.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/brev/BrevKlientImpl.kt
@@ -261,16 +261,3 @@ class BrevKlientImpl(
                 failure = { errorResponse -> throw errorResponse },
             )
 }
-
-// TODO Finnes nå i etterlatte-behandling og brev-api - bør ligge i en lib men er ikke helt landet hvilket lib
-// som bør brukes mellom behandling og brev
-data class BrevPayload(
-    val hoveddel: Slate?,
-    val vedlegg: List<BrevInnholdVedlegg>?,
-)
-
-data class BrevInnholdVedlegg(
-    val tittel: String,
-    val key: BrevVedleggKey,
-    val payload: Slate? = null,
-)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/BrevService.kt
@@ -81,7 +81,12 @@ class BrevService(
                     )
                 },
                 brevKodeMapping = { req.brevKode },
-                brevDataMapping = { ManueltBrevMedTittelData(innhold = it.innholdMedVedlegg.innhold(), data = ManueltBrevMedTittelDataData(tittel = it.tittel)) },
+                brevDataMapping = {
+                    ManueltBrevMedTittelData(
+                        innhold = it.innholdMedVedlegg.innhold(),
+                        data = ManueltBrevMedTittelDataData(tittel = it.tittel),
+                    )
+                },
             )
 
             logger.info("Journalfører brev med id: $brevId")
@@ -125,7 +130,12 @@ class BrevService(
                         )
                     },
                     brevKodeMapping = { hentBrev.brevkoder!! },
-                    brevDataMapping = { ManueltBrevMedTittelData(innhold = it.innholdMedVedlegg.innhold(), data = ManueltBrevMedTittelDataData(tittel = it.tittel)) },
+                    brevDataMapping = {
+                        ManueltBrevMedTittelData(
+                            innhold = it.innholdMedVedlegg.innhold(),
+                            data = ManueltBrevMedTittelDataData(tittel = it.tittel),
+                        )
+                    },
                 )
             }
 
@@ -212,19 +222,14 @@ class BrevService(
                 brevDataMapping = { parametre.brevDataMapping() },
                 brevKodeMapping = { parametre.brevkode },
             )
-        if (innhold.hoveddel != null) {
-            db.oppdaterPayload(brevId, innhold.hoveddel, bruker)
+        innhold.hoveddel?.let {
+            db.oppdaterPayload(brevId, it, bruker)
         }
-        if (innhold.vedlegg != null) {
-            db.oppdaterPayloadVedlegg(brevId, innhold.vedlegg, bruker)
+        innhold.vedlegg?.let {
+            db.oppdaterPayloadVedlegg(brevId, it, bruker)
         }
         return db.hentBrev(brevId)
     }
-
-    data class BrevPayload(
-        val hoveddel: Slate?,
-        val vedlegg: List<BrevInnholdVedlegg>?,
-    )
 
     fun hentBrevPayload(id: BrevID): BrevPayload {
         val hoveddel =
@@ -412,7 +417,9 @@ class BrevService(
             bruker,
             avsenderRequest = { b, vedtak, enhet -> opprettAvsenderRequest(b, vedtak, enhet) },
             brevKodeMapping = { Brevkoder.TOMT_INFORMASJONSBREV },
-            brevDataMapping = { ManueltBrevMedTittelData(innhold = it.innholdMedVedlegg.innhold(), data = ManueltBrevMedTittelDataData(tittel = it.tittel)) },
+            brevDataMapping = {
+                ManueltBrevMedTittelData(innhold = it.innholdMedVedlegg.innhold(), data = ManueltBrevMedTittelDataData(tittel = it.tittel))
+            },
         )
 
     // EY-4963

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/Brevoppretter.kt
@@ -93,7 +93,7 @@ class Brevoppretter(
         bruker: BrukerTokenInfo,
         brevKodeMapping: (b: BrevkodeRequest) -> Brevkoder,
         brevDataMapping: suspend (BrevDataRedigerbarRequest) -> BrevDataRedigerbar,
-    ): BrevService.BrevPayload {
+    ): BrevPayload {
         val spraak = db.hentBrevInnhold(brevId)?.spraak
         val opprinneligBrevkoder = db.hentBrevkoder(brevId)
 
@@ -120,7 +120,7 @@ class Brevoppretter(
                 db.oppdaterTittel(brevId, innhold.tittel, bruker)
             }
 
-            return BrevService.BrevPayload(
+            return BrevPayload(
                 innhold.payload ?: db.hentBrevPayload(brevId),
                 innholdVedlegg ?: db.hentBrevPayloadVedlegg(brevId),
             )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/db/BrevRepository.kt
@@ -81,8 +81,8 @@ class BrevRepository(
             it.run(
                 queryOf(
                     "SELECT brev_id, bytes, opprettet FROM pdf WHERE brev_id = ?",
-                    id
-                ).map(tilPdfMedData).asSingle
+                    id,
+                ).map(tilPdfMedData).asSingle,
             )
         }
 
@@ -96,8 +96,7 @@ class BrevRepository(
             it.run(queryOf("SELECT payload_vedlegg FROM innhold WHERE brev_id = ?", id).map(tilPayloadVedlegg).asSingle)
         }
 
-    fun hentBrevkoder(id: BrevID) =
-        ds.hent(HENT_BREVKODER_QUERY, id) { it.stringOrNull("brevkoder")?.let { Brevkoder.valueOf(it) } }
+    fun hentBrevkoder(id: BrevID) = ds.hent(HENT_BREVKODER_QUERY, id) { it.stringOrNull("brevkoder")?.let { Brevkoder.valueOf(it) } }
 
     fun hentBrevForBehandling(
         behandlingId: UUID,
@@ -158,13 +157,13 @@ class BrevRepository(
                     ),
                 ).asUpdate,
             ).also {
-                krev(it == 1) { "Brev fikk ikke oppdatert vedlegg id: $id" }
+                krev(it == 1) { "Brev med id $id fikk ikke oppdatert vedlegg" }
             }
 
         tx
             .lagreHendelse(id, Status.OPPDATERT, payload.toJson(), bruker)
             .also {
-                krev(it == 1) { "Brev fikk ikke oppdatert hendelse for vedlegg id: $id" }
+                krev(it == 1) { "Brev med id $id fikk ikke oppdatert hendelse for vedlegg" }
             }
     }
 
@@ -530,19 +529,21 @@ class BrevRepository(
                 it.run(
                     queryOf(
                         """
-                    DELETE FROM hendelse WHERE brev_id = :brevId AND status_id = :statusId
-                """.trimIndent(), mapOf(
+                        DELETE FROM hendelse WHERE brev_id = :brevId AND status_id = :statusId
+                        """.trimIndent(),
+                        mapOf(
                             "brevId" to id,
                             "statusId" to Status.FERDIGSTILT.name,
-                        )
-                    ).asUpdate
+                        ),
+                    ).asUpdate,
                 )
                 it.run(
                     queryOf(
                         """
-                    DELETE FROM pdf WHERE brev_id = :brevId
-                """.trimIndent(), mapOf("brevId" to id)
-                    ).asUpdate
+                        DELETE FROM pdf WHERE brev_id = :brevId
+                        """.trimIndent(),
+                        mapOf("brevId" to id),
+                    ).asUpdate,
                 )
             }
         }

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
@@ -5,8 +5,8 @@ import no.nav.etterlatte.brev.BrevData
 import no.nav.etterlatte.brev.BrevDataFerdigstillingNy
 import no.nav.etterlatte.brev.BrevDataRedigerbarNy
 import no.nav.etterlatte.brev.BrevInnholdVedlegg
+import no.nav.etterlatte.brev.BrevPayload
 import no.nav.etterlatte.brev.BrevRequest
-import no.nav.etterlatte.brev.BrevService
 import no.nav.etterlatte.brev.BrevVedleggRedigerbarNy
 import no.nav.etterlatte.brev.Brevtype
 import no.nav.etterlatte.brev.JournalfoerBrevService
@@ -225,7 +225,7 @@ class StrukturertBrevService(
         brevId: Long,
         bruker: BrukerTokenInfo,
         brevRequest: BrevRequest,
-    ): BrevService.BrevPayload {
+    ): BrevPayload {
         val brev = db.hentBrev(brevId)
         if (!brev.kanEndres()) {
             throw UgyldigForespoerselException(
@@ -271,7 +271,7 @@ class StrukturertBrevService(
             db.oppdaterTittel(brevId, brevinnhold.tittel, bruker)
         }
 
-        return BrevService.BrevPayload(
+        return BrevPayload(
             brevinnhold.payload ?: db.hentBrevPayload(brevId),
             innholdVedlegg,
         )

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/StrukturertBrevService.kt
@@ -264,9 +264,7 @@ class StrukturertBrevService(
         }
 
         val innholdVedlegg = hentInnholdForVedlegg(brevRequest.brevVedleggData, avsender, soekerOgEventuellVerge, spraakIBrev, sak)
-        if (innholdVedlegg.isNotEmpty()) {
-            db.oppdaterPayloadVedlegg(brevId, innholdVedlegg, bruker)
-        }
+        db.oppdaterPayloadVedlegg(brevId, innholdVedlegg, bruker)
 
         if (brev.brevkoder != brevInnholdData.brevKode) {
             db.oppdaterBrevkoder(brevId, brevInnholdData.brevKode)

--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/vedtaksbrev/VedtaksbrevService.kt
@@ -1,7 +1,7 @@
 package no.nav.etterlatte.brev.vedtaksbrev
 
 import kotlinx.coroutines.runBlocking
-import no.nav.etterlatte.brev.BrevService
+import no.nav.etterlatte.brev.BrevPayload
 import no.nav.etterlatte.brev.Brevkoder
 import no.nav.etterlatte.brev.Brevoppretter
 import no.nav.etterlatte.brev.Brevtype
@@ -215,7 +215,7 @@ class VedtaksbrevService(
         behandlingId: UUID,
         brukerTokenInfo: BrukerTokenInfo,
         brevtype: Brevtype,
-    ): BrevService.BrevPayload {
+    ): BrevPayload {
         val brev = db.hentBrev(brevId)
         if (!brev.kanEndres()) {
             throw UgyldigForespoerselException(
@@ -226,18 +226,24 @@ class VedtaksbrevService(
 
         return brevoppretter.hentNyttInnhold(sakId, brevId, behandlingId, brukerTokenInfo, {
             when (brevtype) {
-                Brevtype.VARSEL ->
+                Brevtype.VARSEL -> {
                     if (it.sakType === SakType.BARNEPENSJON) {
                         Brevkoder.BP_VARSEL
                     } else {
                         Brevkoder.OMS_VARSEL
                     }
+                }
 
-                Brevtype.VEDTAK -> brevKodeMappingVedtak.brevKode(it)
-                else -> throw UgyldigForespoerselException(
-                    "FEIL_BREVKODE_NYTT_INNHOLD",
-                    "Prøvde å hente brevkode for nytt innhold for brevtype $brevtype, men per nå støtter vi bare vedtak og varsel.",
-                )
+                Brevtype.VEDTAK -> {
+                    brevKodeMappingVedtak.brevKode(it)
+                }
+
+                else -> {
+                    throw UgyldigForespoerselException(
+                        "FEIL_BREVKODE_NYTT_INNHOLD",
+                        "Prøvde å hente brevkode for nytt innhold for brevtype $brevtype, men per nå støtter vi bare vedtak og varsel.",
+                    )
+                }
             }
         }) {
             if (brevtype == Brevtype.VARSEL) {
@@ -274,7 +280,7 @@ class VedtaksbrevService(
         } else {
             logger.warn(
                 "Kan ikke ferdigstille/låse brev når saksbehandler ($saksbehandlerVedtak)" +
-                        " og attestant (${brukerTokenInfo.ident()}) er samme person.",
+                    " og attestant (${brukerTokenInfo.ident()}) er samme person.",
             )
         }
     }
@@ -303,15 +309,16 @@ class VedtaksbrevService(
         }
         if (brev.brevkoder != Brevkoder.TILBAKEKREVING) {
             throw UgyldigForespoerselException(
-                "IKKE_TILBAKEKREVING_BREV", "Ferdigstilling kan kun fjernes for tilbakekrevingsbrev, " +
-                        "men brev med id=${brev.id} til behandling $behandlingId har brevkode ${brev.brevkoder}"
+                "IKKE_TILBAKEKREVING_BREV",
+                "Ferdigstilling kan kun fjernes for tilbakekrevingsbrev, " +
+                    "men brev med id=${brev.id} til behandling $behandlingId har brevkode ${brev.brevkoder}",
             )
         }
 
         if (brev.status != Status.FERDIGSTILT) {
             throw UgyldigForespoerselException(
                 "FERDIGSTILT_KAN_IKKE_FJERNES",
-                "Brevet har status ${brev.status}, og vi kan ikke fjerne ferdigstillingen"
+                "Brevet har status ${brev.status}, og vi kan ikke fjerne ferdigstillingen",
             )
         }
         db.fjernFerdigstiltStatus(brev.id)
@@ -322,26 +329,26 @@ class UgyldigStatusKanIkkeFerdigstilles(
     id: BrevID,
     status: Status,
 ) : UgyldigForespoerselException(
-    code = "UGYLDIG_STATUS_BREV",
-    detail = "Brevet kan ikke ferdigstilles når status er ${status.name.lowercase()}",
-    meta =
-        mapOf(
-            "id" to id,
-            "status" to status,
-        ),
-)
+        code = "UGYLDIG_STATUS_BREV",
+        detail = "Brevet kan ikke ferdigstilles når status er ${status.name.lowercase()}",
+        meta =
+            mapOf(
+                "id" to id,
+                "status" to status,
+            ),
+    )
 
 class VedtaksbrevKanIkkeSlettes(
     brevId: BrevID,
     detalj: String,
 ) : IkkeTillattException(
-    code = "VEDTAKSBREV_KAN_IKKE_SLETTES",
-    detail = "Vedtaksbrevet kan ikke slettes: $detalj",
-    meta =
-        mapOf(
-            "id" to brevId,
-        ),
-)
+        code = "VEDTAKSBREV_KAN_IKKE_SLETTES",
+        detail = "Vedtaksbrevet kan ikke slettes: $detalj",
+        meta =
+            mapOf(
+                "id" to brevId,
+            ),
+    )
 
 class UgyldigAntallMottakere :
     UgyldigForespoerselException(
@@ -354,32 +361,32 @@ class UgyldigMottakerKanIkkeFerdigstilles(
     sakId: SakId,
     feil: List<String>,
 ) : UgyldigForespoerselException(
-    code = "UGYLDIG_MOTTAKER_BREV",
-    detail = "Brevet kan ikke ferdigstilles med ugyldig mottaker og/eller adresse. BrevID: $id, sakId: $sakId. $feil",
-    meta = id?.let { mapOf("id" to it) },
-)
+        code = "UGYLDIG_MOTTAKER_BREV",
+        detail = "Brevet kan ikke ferdigstilles med ugyldig mottaker og/eller adresse. BrevID: $id, sakId: $sakId. $feil",
+        meta = id?.let { mapOf("id" to it) },
+    )
 
 class BrevManglerPDF(
     id: BrevID,
 ) : UgyldigForespoerselException(
-    code = "PDF_MANGLER",
-    detail = "Kan ikke ferdigstille brev siden PDF ikke er ferdig generert og lagret.",
-    meta = mapOf("id" to id),
-)
+        code = "PDF_MANGLER",
+        detail = "Kan ikke ferdigstille brev siden PDF ikke er ferdig generert og lagret.",
+        meta = mapOf("id" to id),
+    )
 
 class SaksbehandlerOgAttestantSammePerson(
     saksbehandler: String,
     attestant: String,
 ) : UgyldigForespoerselException(
-    code = "SAKSBEHANDLER_OG_ATTESTANT_SAMME_PERSON",
-    detail = "Kan ikke ferdigstille vedtaksbrevet når saksbehandler ($saksbehandler) og attestant ($attestant) er samme person.",
-    meta = mapOf("saksbehandler" to saksbehandler, "attestant" to attestant),
-)
+        code = "SAKSBEHANDLER_OG_ATTESTANT_SAMME_PERSON",
+        detail = "Kan ikke ferdigstille vedtaksbrevet når saksbehandler ($saksbehandler) og attestant ($attestant) er samme person.",
+        meta = mapOf("saksbehandler" to saksbehandler, "attestant" to attestant),
+    )
 
 class KanIkkeOppretteVedtaksbrev(
     behandlingId: UUID,
 ) : UgyldigForespoerselException(
-    code = "KAN_IKKE_ENDRE_VEDTAKSBREV",
-    detail = "Statusen til behandlingen tillater ikke at det opprettes vedtaksbrev",
-    meta = mapOf("behandlingId" to behandlingId),
-)
+        code = "KAN_IKKE_ENDRE_VEDTAKSBREV",
+        detail = "Statusen til behandlingen tillater ikke at det opprettes vedtaksbrev",
+        meta = mapOf("behandlingId" to behandlingId),
+    )

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevRouteTest.kt
@@ -21,7 +21,6 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import io.mockk.verify
 import no.nav.etterlatte.behandling.randomSakId
-import no.nav.etterlatte.brev.BrevService.BrevPayload
 import no.nav.etterlatte.brev.distribusjon.Brevdistribuerer
 import no.nav.etterlatte.brev.hentinformasjon.behandling.BehandlingService
 import no.nav.etterlatte.brev.hentinformasjon.grunnlag.GrunnlagService

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/BrevServiceTest.kt
@@ -10,7 +10,6 @@ import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.randomSakId
-import no.nav.etterlatte.brev.BrevService.BrevPayload
 import no.nav.etterlatte.brev.adresse.AdresseService
 import no.nav.etterlatte.brev.brevbaker.BrevbakerKlient
 import no.nav.etterlatte.brev.brevbaker.BrevbakerService

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/VedtaksbrevServiceTest.kt
@@ -700,7 +700,7 @@ internal class VedtaksbrevServiceTest {
                 }
 
             nyttInnhold shouldBe
-                BrevService.BrevPayload(
+                BrevPayload(
                     opphoerPayload,
                     listOf(
                         vedleggPayload(opprettVedleggPayload()),

--- a/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
+++ b/apps/etterlatte-brev-api/src/test/kotlin/no/nav/etterlatte/brev/db/BrevRepositoryIntegrationTest.kt
@@ -2,7 +2,6 @@ package no.nav.etterlatte.brev.db
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.mockk.mockk
@@ -456,7 +455,7 @@ internal class BrevRepositoryIntegrationTest(
                             BrevInnholdVedlegg(
                                 tittel = "tittel",
                                 key = BrevVedleggKey.OMS_BEREGNING,
-                                payload = null,
+                                payload = Slate(),
                             ),
                         ),
                 )
@@ -493,11 +492,11 @@ internal class BrevRepositoryIntegrationTest(
             val vedleggPayload = db.hentBrevPayloadVedlegg(opprettetBrev.id)!!
             vedleggPayload
                 .first()
-                .payload!!
+                .payload
                 .elements.size shouldBeExactly 1
             vedleggPayload
                 .first()
-                .payload!!
+                .payload
                 .elements[0]
                 .type shouldBe Slate.ElementType.HEADING_TWO
         }

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/BrevData.kt
@@ -158,7 +158,7 @@ abstract class BrevVedleggInnholdData : BrevDataRedigerbar {
 data class BrevInnholdVedlegg(
     val tittel: String,
     val key: BrevVedleggKey,
-    val payload: Slate? = null,
+    val payload: Slate,
 )
 
 enum class BrevVedleggKey {
@@ -168,3 +168,8 @@ enum class BrevVedleggKey {
     BP_FORHAANDSVARSEL_FEILUTBETALING,
     OMS_EO_BEREGNINGSVEDLEGG,
 }
+
+data class BrevPayload(
+    val hoveddel: Slate?,
+    val vedlegg: List<BrevInnholdVedlegg>?,
+)

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/EtteroppgjoerBrevData.kt
@@ -51,7 +51,7 @@ object EtteroppgjoerBrevData {
                     innhold()
                         .single {
                             it.key == BrevVedleggKey.OMS_EO_BEREGNINGSVEDLEGG
-                        }.payload!!
+                        }.payload
                         .elements,
             )
 

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelseVedtakBrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadInnvilgelseVedtakBrevData.kt
@@ -34,7 +34,7 @@ object OmstillingsstoenadInnvilgelseVedtakBrevData {
                         innhold =
                             innhold()
                                 .single { it.key == BrevVedleggKey.OMS_BEREGNING }
-                                .payload!!
+                                .payload
                                 .elements,
                     ),
             )

--- a/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurderingVedtakBrevData.kt
+++ b/libs/etterlatte-brev-model/src/main/kotlin/no/nav/etterlatte/brev/model/oms/OmstillingsstoenadRevurderingVedtakBrevData.kt
@@ -48,14 +48,14 @@ object OmstillingsstoenadRevurderingVedtakBrevData {
                         innhold =
                             innhold()
                                 .singleOrNull { it.key == BrevVedleggKey.OMS_BEREGNING }
-                                ?.let { it.payload!!.elements }
+                                ?.let { it.payload.elements }
                                 ?: emptyList(),
                     ),
                 innholdForhaandsvarsel =
                     innhold()
                         .takeIf { feilutbetaling == FeilutbetalingType.FEILUTBETALING_MED_VARSEL }
                         ?.single { it.key == BrevVedleggKey.OMS_FORHAANDSVARSEL_FEILUTBETALING }
-                        ?.let { it.payload!!.elements }
+                        ?.let { it.payload.elements }
                         ?: emptyList(),
             )
 
@@ -100,7 +100,7 @@ object OmstillingsstoenadRevurderingVedtakBrevData {
                             innhold()
                                 .single {
                                     it.key == BrevVedleggKey.OMS_BEREGNING
-                                }.payload!!
+                                }.payload
                                 .elements,
                     ),
             )
@@ -129,7 +129,7 @@ object OmstillingsstoenadRevurderingVedtakBrevData {
                     innhold()
                         .takeIf { feilutbetaling == FeilutbetalingType.FEILUTBETALING_MED_VARSEL }
                         ?.single { it.key == BrevVedleggKey.OMS_FORHAANDSVARSEL_FEILUTBETALING }
-                        ?.let { it.payload!!.elements }
+                        ?.let { it.payload.elements }
                         ?: emptyList(),
             )
     }


### PR DESCRIPTION
Fordi: Hvis vi bytter fra ikke opphør til opphør så henger vedlegg-teksten igjen, ettersom opphør ikke har noen redigerbare vedlegg bortsett fra feilutbetaling hvis det er valgt i brevutfall.
Fjerner også duplikat definisjon av BrevPayload og BrevInnholdVedlegg og gjør BrevInnholdVedlegg.payload påkrevd