### PR TITLE
Forsøk på fix av sikkerlogg som noen ganger ikke logger

### DIFF
--- a/apps/etterlatte-api/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-api/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-behandling-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-behandling-kafka/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-behandling/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-behandling/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-beregning-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-beregning-kafka/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-beregning/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-beregning/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-brev-api/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-brev-api/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-brev-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-brev-kafka/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-egne-ansatte-lytter/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-egne-ansatte-lytter/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-hendelser-joark/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-hendelser-joark/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-hendelser-pdl/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-hendelser-pdl/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-hendelser-samordning/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-hendelser-samordning/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-hendelser-ufoere/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-hendelser-ufoere/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-institusjonsopphold/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-institusjonsopphold/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-klage/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-klage/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-pdltjenester/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-pdltjenester/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-statistikk/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-statistikk/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-testdata-behandler/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-testdata-behandler/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-tidshendelser/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-tidshendelser/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-tilbakekreving/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-tilbakekreving/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-trygdetid-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-trygdetid-kafka/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-trygdetid/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-trygdetid/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-utbetaling/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-utbetaling/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}

--- a/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback-secure.xml
+++ b/apps/etterlatte-vedtaksvurdering-kafka/src/main/resources/logback-secure.xml
@@ -2,6 +2,7 @@
 <included>
     <appender name="secureAppender" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
         <destination>team-logs.nais-system:5170</destination>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder">
             <customFields>
                 {"google_cloud_project":"${GOOGLE_CLOUD_PROJECT}","nais_namespace_name":"${NAIS_NAMESPACE}","nais_pod_name":"${NAIS_POD_NAME}","nais_container_name":"${NAIS_APP_NAME}"}


### PR DESCRIPTION
Etter sparring med copilot er hypotesen som følger:
LogstashTcpSocketAppender etablerer en TCP-kobling til team-logs ved oppstart, men sender ingen keepalive-pakker. Etter et gitt antall minutter/timer uten sikkerLogg-aktivitet lukker nettverket/team-logs koblingen stille.

Neste sikkerLogg-melding skrives til en død socket, ser ut til å lykkes lokalt (OS-buffer), men når aldri frem. Appenderen oppdager feilen først på etterfølgende skriv og re-kobler – men da er meldingen allerede tapt.

Legger til <keepAliveDuration>5 minutes</keepAliveDuration> i alle 23 appene slik at appenderen sender periodiske keepalive-pakker og oppdager brutte koblinger før neste melding skal sendes.

Dette gir forøvrig også en god forklaring på hvorfor dette er vanskelig å gjenskape i dev, og derfor merger jeg dette forsøket på en fix, og følger med på logging videre. Ønsker å få beskjed så fort som mulig om noen oppdager at det fortsatt er noe som ikke logges til securelogger.