### PR TITLE
Brevdata-henting for opphørsvedtak rettes, slik at det ikke hentes avkorting og trygdetid.

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/OmstillingsstoenadVedtaksbrevGrunnlag.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/OmstillingsstoenadVedtaksbrevGrunnlag.kt
@@ -24,10 +24,7 @@ import java.time.LocalDate
 
 internal data class OmstillingsstoenadVedtaksbrevGrunnlag(
     val virkningsdato: LocalDate,
-    val avkortingsinfo: Avkortingsinfo,
-    val beregningsperioder: List<OmstillingsstoenadBeregningsperiode>,
     val alleLand: List<LandDto>,
-    val trygdetid: List<TrygdetidDto>,
     val sak: Sak,
     val grunnlag: Grunnlag,
     val avdoede: List<Avdoed>,
@@ -53,3 +50,9 @@ internal data class OmstillingsstoenadVedtaksbrevGrunnlag(
                 ?.let(FeilutbetalingType::fromFeilutbetalingValg),
         ) { "Feilutbetaling mangler i brevutfall" }
 }
+
+internal data class OmstillingsstoenadVedtaksbrevGrunnlagForLoependeYtelse(
+    val avkortingsinfo: Avkortingsinfo,
+    val beregningsperioder: List<OmstillingsstoenadBeregningsperiode>,
+    val trygdetid: TrygdetidDto,
+)

--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/VedtaksbrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/VedtaksbrevService.kt
@@ -162,6 +162,7 @@ class VedtaksbrevService(
         skalLagres: Boolean = false,
     ): BrevRequest {
         val fellesData = hentFellesData(behandling, vedtak, brukerTokenInfo)
+        val fellesDataLoepende = hentFellesdataForLoependeYtelse(behandling, vedtak, brukerTokenInfo)
         val erTidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar == true
         val doedsdatoEllerOpphoertPleieforhold =
             if (erTidligereFamiliepleier) {
@@ -185,8 +186,8 @@ class VedtaksbrevService(
                     beregning =
                         omsBeregning(
                             behandling = behandling,
-                            trygdetid = fellesData.trygdetid.single(),
-                            avkortingsinfo = fellesData.avkortingsinfo,
+                            trygdetid = fellesDataLoepende.trygdetid,
+                            avkortingsinfo = fellesDataLoepende.avkortingsinfo,
                             landKodeverk = fellesData.alleLand,
                         ),
                     innvilgetMindreEnnFireMndEtterDoedsfall =
@@ -194,11 +195,11 @@ class VedtaksbrevService(
                             doedsdatoEllerOpphoertPleieforhold = doedsdatoEllerOpphoertPleieforhold,
                         ),
                     omsRettUtenTidsbegrensning = fellesData.omsRettUtenTidsbegrensning,
-                    harUtbetaling = fellesData.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
+                    harUtbetaling = fellesDataLoepende.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                     bosattUtland = behandling.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND,
                     etterbetaling =
                         fellesData.etterbetaling?.let { dto ->
-                            Etterbetaling.fraOmstillingsstoenadBeregningsperioder(dto, fellesData.beregningsperioder)
+                            Etterbetaling.fraOmstillingsstoenadBeregningsperioder(dto, fellesDataLoepende.beregningsperioder)
                         },
                     erSluttbehandling = behandling.erSluttbehandling,
                     tidligereFamiliepleier = erTidligereFamiliepleier,
@@ -208,7 +209,7 @@ class VedtaksbrevService(
                 OmstillingsstoenadInnvilgelseVedtakBrevData.VedtakInnhold(
                     virkningsdato = fellesData.virkningsdato,
                     utbetalingsbeloep =
-                        fellesData.avkortingsinfo.beregningsperioder
+                        fellesDataLoepende.avkortingsinfo.beregningsperioder
                             .firstOrNull()
                             ?.utbetaltBeloep
                             ?: throw UgyldigForespoerselException(
@@ -220,12 +221,12 @@ class VedtaksbrevService(
                     datoVedtakOmgjoering = fellesData.klage?.datoVedtakOmgjoering(),
                     avdoed = if (erTidligereFamiliepleier) null else fellesData.avdoede.single(),
                     erSluttbehandling = behandling.erSluttbehandling,
-                    harUtbetaling = fellesData.harUtbetaling(),
+                    harUtbetaling = fellesDataLoepende.harUtbetaling(),
                     beregning =
                         omsBeregning(
                             behandling = behandling,
-                            trygdetid = fellesData.trygdetid.single(),
-                            avkortingsinfo = fellesData.avkortingsinfo,
+                            trygdetid = fellesDataLoepende.trygdetid,
+                            avkortingsinfo = fellesDataLoepende.avkortingsinfo,
                             landKodeverk = emptyList(),
                         ),
                 ),
@@ -237,11 +238,11 @@ class VedtaksbrevService(
                                 omstillingsstoenadBeregning =
                                     omsBeregning(
                                         behandling = behandling,
-                                        trygdetid = fellesData.trygdetid.single(),
-                                        avkortingsinfo = fellesData.avkortingsinfo,
+                                        trygdetid = fellesDataLoepende.trygdetid,
+                                        avkortingsinfo = fellesDataLoepende.avkortingsinfo,
                                         landKodeverk = fellesData.alleLand,
                                     ),
-                                erInnvilgelsesAar = fellesData.avkortingsinfo.erInnvilgelsesaar,
+                                erInnvilgelsesAar = fellesDataLoepende.avkortingsinfo.erInnvilgelsesaar,
                             ),
                         vedlegg = Vedlegg.OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL,
                         vedleggId = BrevVedleggKey.OMS_BEREGNING,
@@ -257,8 +258,9 @@ class VedtaksbrevService(
         skalLagres: Boolean = false,
     ): BrevRequest {
         val fellesData = hentFellesData(behandling, vedtak, brukerTokenInfo)
+        val fellesDataLoepende = hentFellesdataForLoependeYtelse(behandling, vedtak, brukerTokenInfo)
 
-        val beregningsperioderOpphoer = utledBeregningsperioderOpphoer(behandling, fellesData.beregningsperioder)
+        val beregningsperioderOpphoer = utledBeregningsperioderOpphoer(behandling, fellesDataLoepende.beregningsperioder)
         val sisteBeregningsperiode = beregningsperioderOpphoer.sisteBeregningsperiode
 
         return BrevRequest(
@@ -274,21 +276,21 @@ class VedtaksbrevService(
             brevFastInnholdData =
                 OmstillingsstoenadRevurderingVedtakBrevData.Vedtak(
                     erEndret =
-                        fellesData.avkortingsinfo.endringIUtbetalingVedVirk ||
+                        fellesDataLoepende.avkortingsinfo.endringIUtbetalingVedVirk ||
                             behandling.revurderingsaarsak == FRA_0UTBETALING_TIL_UTBETALING,
                     erOmgjoering = behandling.revurderingsaarsak == OMGJOERING_ETTER_KLAGE,
                     datoVedtakOmgjoering = fellesData.klage?.datoVedtakOmgjoering(),
                     beregning =
                         omsBeregning(
                             behandling = behandling,
-                            trygdetid = fellesData.trygdetid.single(),
-                            avkortingsinfo = fellesData.avkortingsinfo,
+                            trygdetid = fellesDataLoepende.trygdetid,
+                            avkortingsinfo = fellesDataLoepende.avkortingsinfo,
                             landKodeverk = fellesData.alleLand,
                         ),
                     omsRettUtenTidsbegrensning = fellesData.omsRettUtenTidsbegrensning,
                     feilutbetaling = fellesData.feilutbetalingFraBrevutfall(),
                     bosattUtland = behandling.utlandstilknytning?.type == UtlandstilknytningType.BOSATT_UTLAND,
-                    erInnvilgelsesaar = fellesData.avkortingsinfo.erInnvilgelsesaar,
+                    erInnvilgelsesaar = fellesDataLoepende.avkortingsinfo.erInnvilgelsesaar,
                     tidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar == true,
                 ),
             brevRedigerbarInnholdData =
@@ -296,7 +298,7 @@ class VedtaksbrevService(
                     beregning =
                         OmstillingsstoenadBeregningRedigerbartUtfall(
                             virkningsdato = fellesData.virkningsdato,
-                            beregningsperioder = fellesData.beregningsperioder,
+                            beregningsperioder = fellesDataLoepende.beregningsperioder,
                             sisteBeregningsperiode = sisteBeregningsperiode,
                             sisteBeregningsperiodeNesteAar = beregningsperioderOpphoer.sisteBeregningsperiodeNesteAar,
                             oppphoersdato = beregningsperioderOpphoer.forventetOpphoerDato,
@@ -304,19 +306,19 @@ class VedtaksbrevService(
                                 beregningsperioderOpphoer.forventetOpphoerDato?.year == (behandling.virkningstidspunkt().dato.year + 1),
                         ),
                     erEndret =
-                        fellesData.avkortingsinfo.endringIUtbetalingVedVirk ||
+                        fellesDataLoepende.avkortingsinfo.endringIUtbetalingVedVirk ||
                             behandling.revurderingsaarsak == FRA_0UTBETALING_TIL_UTBETALING,
                     erEtterbetaling = fellesData.etterbetaling != null,
                     etterbetaling =
                         fellesData.etterbetaling?.let {
                             Etterbetaling.fraOmstillingsstoenadBeregningsperioder(
                                 it,
-                                fellesData.beregningsperioder,
+                                fellesDataLoepende.beregningsperioder,
                             )
                         },
                     feilutbetaling = fellesData.feilutbetalingFraBrevutfall(),
-                    harFlereUtbetalingsperioder = fellesData.beregningsperioder.size > 1,
-                    harUtbetaling = fellesData.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
+                    harFlereUtbetalingsperioder = fellesDataLoepende.beregningsperioder.size > 1,
+                    harUtbetaling = fellesDataLoepende.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
                     inntekt = sisteBeregningsperiode.inntekt,
                     inntektsAar = sisteBeregningsperiode.datoFOM.year,
                     mottattInntektendringAutomatisk =
@@ -337,11 +339,11 @@ class VedtaksbrevService(
                                 omstillingsstoenadBeregning =
                                     omsBeregning(
                                         behandling = behandling,
-                                        trygdetid = fellesData.trygdetid.single(),
-                                        avkortingsinfo = fellesData.avkortingsinfo,
+                                        trygdetid = fellesDataLoepende.trygdetid,
+                                        avkortingsinfo = fellesDataLoepende.avkortingsinfo,
                                         landKodeverk = fellesData.alleLand,
                                     ),
-                                erInnvilgelsesAar = fellesData.avkortingsinfo.erInnvilgelsesaar,
+                                erInnvilgelsesAar = fellesDataLoepende.avkortingsinfo.erInnvilgelsesaar,
                             ),
                         vedlegg = Vedlegg.OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL,
                         vedleggId = BrevVedleggKey.OMS_BEREGNING,
@@ -366,15 +368,16 @@ class VedtaksbrevService(
         skalLagres: Boolean = false,
     ): BrevRequest {
         val fellesData = hentFellesData(behandling, vedtak, brukerTokenInfo)
+        val fellesDataLoepende = hentFellesdataForLoependeYtelse(behandling, vedtak, brukerTokenInfo)
 
-        val beregningsperioderOpphoer = utledBeregningsperioderOpphoer(behandling, fellesData.beregningsperioder)
+        val beregningsperioderOpphoer = utledBeregningsperioderOpphoer(behandling, fellesDataLoepende.beregningsperioder)
         val sisteBeregningsperiode = beregningsperioderOpphoer.sisteBeregningsperiode
 
         val beregning =
             omsBeregning(
                 behandling = behandling,
-                trygdetid = fellesData.trygdetid.single(),
-                avkortingsinfo = fellesData.avkortingsinfo,
+                trygdetid = fellesDataLoepende.trygdetid,
+                avkortingsinfo = fellesDataLoepende.avkortingsinfo,
                 landKodeverk = fellesData.alleLand,
             )
         return BrevRequest(
@@ -394,8 +397,8 @@ class VedtaksbrevService(
                     omsRettUtenTidsbegrensning = fellesData.omsRettUtenTidsbegrensning,
                     tidligereFamiliepleier = behandling.tidligereFamiliepleier?.svar == true,
                     inntektsaar = fellesData.virkningsdato.year,
-                    harUtbetaling = fellesData.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
-                    endringIUtbetaling = fellesData.avkortingsinfo.endringIUtbetalingVedVirk,
+                    harUtbetaling = fellesDataLoepende.beregningsperioder.any { it.utbetaltBeloep.value > 0 },
+                    endringIUtbetaling = fellesDataLoepende.avkortingsinfo.endringIUtbetalingVedVirk,
                     virkningstidspunkt = fellesData.virkningsdato,
                     bosattUtland = behandling.erBosattUtland(),
                 ),
@@ -410,7 +413,7 @@ class VedtaksbrevService(
                         data =
                             OmstillingsstoenadBeregningRedigerbartVedleggData(
                                 omstillingsstoenadBeregning = beregning,
-                                erInnvilgelsesAar = fellesData.avkortingsinfo.erInnvilgelsesaar,
+                                erInnvilgelsesAar = fellesDataLoepende.avkortingsinfo.erInnvilgelsesaar,
                             ),
                         vedlegg = Vedlegg.OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL,
                         vedleggId = BrevVedleggKey.OMS_BEREGNING,
@@ -471,18 +474,6 @@ class VedtaksbrevService(
             val virkningsdato = (vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto).virkningstidspunkt.atDay(1)
 
             val alleLand = async { kodeverkService.hentAlleLand(brukerTokenInfo) }
-            val trygdetid = async { trygdetidKlient.hentTrygdetid(behandlingId, brukerTokenInfo) }
-
-            val avkorting = beregningKlient.hentBeregningOgAvkorting(behandlingId, brukerTokenInfo)
-            val avkortingsinfo =
-                Avkortingsinfo(
-                    virkningsdato = virkningsdato,
-                    beregningsperioder = avkorting.perioder.map { it.toAvkortetBeregningsperiode() },
-                    endringIUtbetalingVedVirk = avkorting.endringIUtbetalingVedVirk,
-                    erInnvilgelsesaar = avkorting.erInnvilgelsesaar,
-                )
-            val beregningsperioder =
-                avkortingsinfo.beregningsperioder.map { it.tilOmstillingsstoenadBeregningsperiode() }
 
             val sak = krevIkkeNull(sakService.finnSak(behandling.sak)) { "Sak må finnes" }
             val grunnlag =
@@ -491,9 +482,6 @@ class VedtaksbrevService(
             val avdoede = grunnlag.mapAvdoede()
             val klage = hentKlageForBehandling(behandling)
             val etterbetaling = behandlingInfoService.hentEtterbetaling(behandlingId)?.toEtterbetalingDTO()
-
-            val trygdetidAwait = trygdetid.await()
-            krev(trygdetidAwait.isNotEmpty()) { "Klarte ikke hente trygdetid for å generere vedtaksbrev" }
 
             val vilkaarsvurdering =
                 krevIkkeNull(vilkaarsvurderingService.hentVilkaarsvurdering(behandlingId)) { "Mangler vilkårsvurdering" }
@@ -517,10 +505,7 @@ class VedtaksbrevService(
 
             OmstillingsstoenadVedtaksbrevGrunnlag(
                 virkningsdato = virkningsdato,
-                avkortingsinfo = avkortingsinfo,
-                beregningsperioder = beregningsperioder,
                 alleLand = alleLand.await(),
-                trygdetid = trygdetidAwait,
                 sak = sak,
                 grunnlag = grunnlag,
                 avdoede = avdoede,
@@ -530,6 +515,37 @@ class VedtaksbrevService(
                 brevutfall = brevutfall,
                 saksbehandlerIdent = saksbehandlerIdent,
                 attestantIdent = attestantIdent,
+            )
+        }
+
+    private suspend fun hentFellesdataForLoependeYtelse(
+        behandling: DetaljertBehandling,
+        vedtak: VedtakDto,
+        brukerTokenInfo: BrukerTokenInfo,
+    ): OmstillingsstoenadVedtaksbrevGrunnlagForLoependeYtelse =
+        coroutineScope {
+            val trygdetidRequest = async { trygdetidKlient.hentTrygdetid(behandling.id, brukerTokenInfo) }
+
+            // TODO felles?
+            val virkningsdato = (vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto).virkningstidspunkt.atDay(1)
+
+            val avkorting = beregningKlient.hentBeregningOgAvkorting(behandling.id, brukerTokenInfo)
+            val avkortingsinfo =
+                Avkortingsinfo(
+                    virkningsdato = virkningsdato,
+                    beregningsperioder = avkorting.perioder.map { it.toAvkortetBeregningsperiode() },
+                    endringIUtbetalingVedVirk = avkorting.endringIUtbetalingVedVirk,
+                    erInnvilgelsesaar = avkorting.erInnvilgelsesaar,
+                )
+            val beregningsperioder =
+                avkortingsinfo.beregningsperioder.map { it.tilOmstillingsstoenadBeregningsperiode() }
+
+            val trygdetid = trygdetidRequest.await()
+            krev(trygdetid.isNotEmpty()) { "Klarte ikke hente trygdetid for å generere vedtaksbrev" }
+            OmstillingsstoenadVedtaksbrevGrunnlagForLoependeYtelse(
+                avkortingsinfo = avkortingsinfo,
+                beregningsperioder = beregningsperioder,
+                trygdetid = trygdetid.single(),
             )
         }
 
@@ -577,7 +593,7 @@ fun innvilgetMindreEnnFireMndEtterDoedsfall(
     doedsdatoEllerOpphoertPleieforhold: LocalDate,
 ): Boolean = innvilgelsesDato.isBefore(doedsdatoEllerOpphoertPleieforhold.plusMonths(4))
 
-private fun OmstillingsstoenadVedtaksbrevGrunnlag.harUtbetaling(): Boolean =
+private fun OmstillingsstoenadVedtaksbrevGrunnlagForLoependeYtelse.harUtbetaling(): Boolean =
     avkortingsinfo.beregningsperioder.any {
         it.utbetaltBeloep.value >
             0

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/VedtaksbrevServiceTest.kt
@@ -1,10 +1,26 @@
 package no.nav.etterlatte.behandling
 
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
+import kotlinx.coroutines.runBlocking
 import no.nav.etterlatte.behandling.klage.KlageService
+import no.nav.etterlatte.behandling.klienter.BeregningKlient
+import no.nav.etterlatte.behandling.klienter.TrygdetidKlient
+import no.nav.etterlatte.behandling.klienter.VedtakInternalService
+import no.nav.etterlatte.behandling.vedtaksvurdering.vedtak
+import no.nav.etterlatte.brev.BrevKlient
+import no.nav.etterlatte.brev.BrevRequest
+import no.nav.etterlatte.brev.model.FeilutbetalingType
+import no.nav.etterlatte.brev.model.oms.OmstillingsstoenadBeregningRedigerbartVedleggData
+import no.nav.etterlatte.brev.model.oms.OmstillingsstoenadRevurderingVedtakBrevData
 import no.nav.etterlatte.common.Enheter
+import no.nav.etterlatte.grunnlag.GrunnlagService
+import no.nav.etterlatte.ktor.token.simpleSaksbehandler
 import no.nav.etterlatte.libs.common.Vedtaksloesning
 import no.nav.etterlatte.libs.common.behandling.BehandlingOpprinnelse
 import no.nav.etterlatte.libs.common.behandling.BehandlingStatus
@@ -14,29 +30,71 @@ import no.nav.etterlatte.libs.common.behandling.Klage
 import no.nav.etterlatte.libs.common.behandling.Prosesstype
 import no.nav.etterlatte.libs.common.behandling.Revurderingaarsak
 import no.nav.etterlatte.libs.common.behandling.SakType
+import no.nav.etterlatte.libs.common.behandling.Virkningstidspunkt
+import no.nav.etterlatte.libs.common.beregning.BeregningOgAvkortingDto
+import no.nav.etterlatte.libs.common.beregning.BeregningsMetode
+import no.nav.etterlatte.libs.common.periode.Periode
 import no.nav.etterlatte.libs.common.sak.Sak
 import no.nav.etterlatte.libs.common.sak.SakId
+import no.nav.etterlatte.libs.common.vedtak.VedtakType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Delvilkaar
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Utfall
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaar
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarType
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.Vilkaarsvurdering
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingResultat
+import no.nav.etterlatte.libs.common.vilkaarsvurdering.VilkaarsvurderingUtfall
+import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
+import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
+import no.nav.etterlatte.sak.SakService
+import no.nav.etterlatte.vilkaarsvurdering.service.VilkaarsvurderingService
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.security.SecureRandom
+import java.time.LocalDateTime
+import java.time.Month
+import java.time.YearMonth
 import java.util.UUID
 
 internal class VedtaksbrevServiceTest {
     private val klageService = mockk<KlageService>()
+    private val brukerTokenInfo = simpleSaksbehandler("Z123456")
+
+    private val behandlingServiceMock = mockk<BehandlingService>()
+    private val vedtakInternalService = mockk<VedtakInternalService>()
+    private val trygdetidKlient = mockk<TrygdetidKlient>()
+    private val vilkaarsvurderingService = mockk<VilkaarsvurderingService>()
+    private val sakService = mockk<SakService>()
+    private val beregningKlient = mockk<BeregningKlient>()
+
+    private val grunnlagService = mockk<GrunnlagService>()
+    private val brevKlient = mockk<BrevKlient>()
 
     private val service =
         VedtaksbrevService(
-            grunnlagService = mockk(relaxed = true),
-            vedtakInternalService = mockk(relaxed = true),
-            brevKlient = mockk(relaxed = true),
-            behandlingService = mockk(relaxed = true),
-            beregningKlient = mockk(relaxed = true),
+            grunnlagService = grunnlagService,
+            vedtakInternalService = vedtakInternalService,
+            brevKlient = brevKlient,
+            behandlingService = behandlingServiceMock,
+            beregningKlient = beregningKlient,
             behandlingInfoService = mockk(relaxed = true),
-            trygdetidKlient = mockk(relaxed = true),
-            vilkaarsvurderingService = mockk(relaxed = true),
-            sakService = mockk(relaxed = true),
+            trygdetidKlient = trygdetidKlient,
+            vilkaarsvurderingService = vilkaarsvurderingService,
+            sakService = sakService,
             klageService = klageService,
             kodeverkService = mockk(relaxed = true),
             oppgaveService = mockk(relaxed = true),
         )
+
+    @BeforeEach
+    fun setUp() {
+        coEvery {
+            grunnlagService.hentOpplysningsgrunnlag(any())
+        } returns GrunnlagTestData().hentOpplysningsgrunnlag()
+        coEvery {
+            brevKlient.opprettStrukturertBrev(any(), any(), any())
+        } returns mockk()
+    }
 
     @Test
     fun `hentKlageForBehandling returnerer null naar relatertBehandlingId er null`() {
@@ -90,18 +148,156 @@ internal class VedtaksbrevServiceTest {
         resultat shouldBe klage
     }
 
+    @Test
+    fun `oppretter vedtaksbrev for endring`() {
+        val sakType = SakType.OMSTILLINGSSTOENAD
+        val sakId = SakId(1336)
+        val sak = Sak("fnr", sakType, sakId, Enheter.defaultEnhet.enhetNr, null, null)
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(dato = YearMonth.of(2024, Month.MARCH))
+        val revurdering =
+            lagDetaljertBehandling(
+                type = BehandlingType.REVURDERING,
+                sakId = sak.id,
+                virkningstidspunkt = virkningstidspunkt,
+            )
+        val vedtak =
+            vedtak(
+                id = SecureRandom().nextLong(),
+                virkningstidspunkt = virkningstidspunkt.dato,
+                sakId = sakId,
+                sakType = sakType,
+                behandlingId = revurdering.id,
+                type = VedtakType.ENDRING,
+            )
+        every { sakService.finnSak(sakId) } returns sak
+
+        every { behandlingServiceMock.hentDetaljertBehandling(revurdering.id, brukerTokenInfo) } returns revurdering
+        coEvery { vedtakInternalService.hentVedtak(revurdering.id, brukerTokenInfo) } returns vedtak.toDto()
+        coEvery {
+            vilkaarsvurderingService.hentVilkaarsvurdering(revurdering.id)
+        } returns
+            vilkaarsvurdering(
+                behandlingId = revurdering.id,
+                virkningstidspunkt = virkningstidspunkt.dato,
+                utfall = VilkaarsvurderingUtfall.OPPFYLT,
+                omsRettUtenTidsbegrensning = Utfall.OPPFYLT,
+            )
+        coEvery {
+            beregningKlient.hentBeregningOgAvkorting(revurdering.id, brukerTokenInfo)
+        } returns
+            beregningOgAvkortingDto(
+                behandling = revurdering,
+                metode = BeregningsMetode.NASJONAL,
+            )
+        coEvery {
+            trygdetidKlient.hentTrygdetid(revurdering.id, brukerTokenInfo)
+        } returns listOf(mockk(relaxed = true))
+
+        runBlocking {
+            service.opprettVedtaksbrev(revurdering.id, bruker = brukerTokenInfo)
+        }
+
+        val brevSlot = slot<BrevRequest>()
+        coVerify {
+            brevKlient.opprettStrukturertBrev(
+                revurdering.id,
+                capture(brevSlot),
+                eq(brukerTokenInfo),
+            )
+        }
+
+        with(brevSlot.captured) {
+            this.sak.id shouldBe sakId
+            (this.brevFastInnholdData as OmstillingsstoenadRevurderingVedtakBrevData.Vedtak).let {
+                it.omsRettUtenTidsbegrensning shouldBe true
+                it.feilutbetaling shouldBe FeilutbetalingType.INGEN_FEILUTBETALING
+                it.bosattUtland shouldBe false
+                it.innholdForhaandsvarsel shouldBe emptyList()
+                it.beregning.trygdetid.beregningsMetodeAnvendt shouldBe BeregningsMetode.NASJONAL
+                it.beregning.beregningsperioder shouldHaveSize 1
+            }
+            (this.brevRedigerbarInnholdData as OmstillingsstoenadRevurderingVedtakBrevData.VedtakInnhold).let {
+                it.feilutbetaling shouldBe FeilutbetalingType.INGEN_FEILUTBETALING
+            }
+            (this.brevVedleggData.single().data as OmstillingsstoenadBeregningRedigerbartVedleggData).let {
+                it.omstillingsstoenadBeregning.beregningsperioder shouldHaveSize 1
+                it.omstillingsstoenadBeregning.trygdetid.beregningsMetodeAnvendt shouldBe BeregningsMetode.NASJONAL
+                it.omstillingsstoenadBeregning.virkningsdato shouldBe virkningstidspunkt.dato.atDay(1)
+            }
+        }
+    }
+
+    @Test
+    fun `oppretter vedtaksbrev for opphoer`() {
+        val sakType = SakType.OMSTILLINGSSTOENAD
+        val sakId = SakId(1336)
+        val sak = Sak("fnr", sakType, sakId, Enheter.defaultEnhet.enhetNr, null, null)
+        val virkningstidspunkt = VirkningstidspunktTestData.virkningstidsunkt(dato = YearMonth.of(2024, Month.MARCH))
+        val revurdering =
+            lagDetaljertBehandling(
+                type = BehandlingType.REVURDERING,
+                sakId = sak.id,
+                virkningstidspunkt = virkningstidspunkt,
+            )
+        val vedtak =
+            vedtak(
+                id = SecureRandom().nextLong(),
+                virkningstidspunkt = virkningstidspunkt.dato,
+                sakId = sakId,
+                sakType = sakType,
+                behandlingId = revurdering.id,
+                type = VedtakType.OPPHOER,
+            )
+        every { sakService.finnSak(sakId) } returns sak
+
+        every { behandlingServiceMock.hentDetaljertBehandling(revurdering.id, brukerTokenInfo) } returns revurdering
+        coEvery { vedtakInternalService.hentVedtak(revurdering.id, brukerTokenInfo) } returns vedtak.toDto()
+        coEvery {
+            vilkaarsvurderingService.hentVilkaarsvurdering(revurdering.id)
+        } returns vilkaarsvurdering(revurdering.id, virkningstidspunkt.dato, VilkaarsvurderingUtfall.IKKE_OPPFYLT)
+
+        runBlocking {
+            service.opprettVedtaksbrev(revurdering.id, bruker = brukerTokenInfo)
+        }
+
+        val brevSlot = slot<BrevRequest>()
+        coVerify {
+            brevKlient.opprettStrukturertBrev(
+                revurdering.id,
+                capture(brevSlot),
+                eq(brukerTokenInfo),
+            )
+        }
+
+        with(brevSlot.captured) {
+            this.sak.id shouldBe sakId
+            (this.brevFastInnholdData as OmstillingsstoenadRevurderingVedtakBrevData.VedtakOpphoer).let {
+                it.virkningsdato shouldBe virkningstidspunkt.dato.atDay(1)
+                it.feilutbetaling shouldBe FeilutbetalingType.INGEN_FEILUTBETALING
+                it.bosattUtland shouldBe false
+                it.innholdForhaandsvarsel shouldBe emptyList()
+            }
+            (this.brevRedigerbarInnholdData as OmstillingsstoenadRevurderingVedtakBrevData.VedtakInnholdOpphoer).let {
+                it.feilutbetaling shouldBe FeilutbetalingType.INGEN_FEILUTBETALING
+            }
+            this.brevVedleggData shouldBe emptyList()
+        }
+    }
+
     private fun lagDetaljertBehandling(
         type: BehandlingType,
         aarsak: Revurderingaarsak? = null,
         relatertBehandlingId: UUID? = null,
+        sakId: SakId = SAK_ID,
+        virkningstidspunkt: Virkningstidspunkt? = null,
     ) = DetaljertBehandling(
         id = UUID.randomUUID(),
-        sak = SAK_ID,
+        sak = sakId,
         sakType = SakType.OMSTILLINGSSTOENAD,
         soeker = "123",
         status = BehandlingStatus.OPPRETTET,
         behandlingType = type,
-        virkningstidspunkt = null,
+        virkningstidspunkt = virkningstidspunkt,
         boddEllerArbeidetUtlandet = null,
         utlandstilknytning = null,
         revurderingsaarsak = aarsak,
@@ -124,4 +320,50 @@ internal class VedtaksbrevServiceTest {
     private companion object {
         val SAK_ID = SakId(1L)
     }
+
+    private fun vilkaarsvurdering(
+        behandlingId: UUID,
+        virkningstidspunkt: YearMonth,
+        utfall: VilkaarsvurderingUtfall,
+        omsRettUtenTidsbegrensning: Utfall = Utfall.IKKE_OPPFYLT,
+    ): Vilkaarsvurdering =
+        Vilkaarsvurdering(
+            behandlingId = behandlingId,
+            grunnlagVersjon = 1L,
+            virkningstidspunkt = virkningstidspunkt,
+            vilkaar =
+                listOf(
+                    Vilkaar(
+                        hovedvilkaar =
+                            Delvilkaar(
+                                type = VilkaarType.OMS_RETT_UTEN_TIDSBEGRENSNING,
+                                lovreferanse = mockk(relaxed = true),
+                                resultat = omsRettUtenTidsbegrensning,
+                            ),
+                    ),
+                ),
+            resultat =
+                VilkaarsvurderingResultat(
+                    utfall = utfall,
+                    kommentar = null,
+                    tidspunkt = LocalDateTime.now(),
+                    saksbehandler = "JABO",
+                ),
+        )
+
+    private fun beregningOgAvkortingDto(
+        behandling: DetaljertBehandling,
+        metode: BeregningsMetode,
+    ): BeregningOgAvkortingDto =
+        BeregningOgAvkortingDto(
+            perioder =
+                listOf(
+                    mockk(relaxed = true) {
+                        every { beregningsMetode } returns metode
+                        every { periode } returns Periode(fom = behandling.virkningstidspunkt!!.dato, tom = null)
+                    },
+                ),
+            erInnvilgelsesaar = true,
+            endringIUtbetalingVedVirk = true,
+        )
 }

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/TestHelper.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/vedtaksvurdering/TestHelper.kt
@@ -121,6 +121,7 @@ fun vedtak(
     vedtakFattet: VedtakFattet? = null,
     attestasjon: Attestasjon? = null,
     utbetalingsperioder: List<Utbetalingsperiode>? = null,
+    type: VedtakType = VedtakType.INNVILGELSE,
 ) = Vedtak(
     id = id,
     status = status,
@@ -128,7 +129,7 @@ fun vedtak(
     sakId = sakId,
     sakType = sakType,
     behandlingId = behandlingId,
-    type = VedtakType.INNVILGELSE,
+    type = type,
     vedtakFattet = vedtakFattet,
     attestasjon = attestasjon,
     innhold =


### PR DESCRIPTION
Relatert til: (https://jira.adeo.no/browse/FAGSYSTEM-437077)