### PR TITLE
Simulering: brutto, skatt og netto etterbetaling

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/SimuleringGruppertPaaAar.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/SimuleringGruppertPaaAar.tsx
@@ -2,7 +2,30 @@ import { Accordion, Box, Heading, Table, VStack } from '@navikt/ds-react'
 import { getYear } from 'date-fns'
 import { SimulertBeregning, SimulertBeregningsperiode } from '~shared/types/Utbetaling'
 import { NOK } from '~utils/formatering/formatering'
-import { summerPerioder, UtbetalingTable } from './UtbetalingTable'
+import { summerEtterbetaling, summerPerioder, UtbetalingTable } from './UtbetalingTable'
+
+const EtterbetalingRader = ({
+  etterbetaling,
+  suffix = '',
+}: {
+  etterbetaling: ReturnType<typeof summerEtterbetaling>
+  suffix?: string
+}) => (
+  <>
+    <Table.Row>
+      <Table.DataCell>Brutto etterbetaling{suffix}</Table.DataCell>
+      <Table.DataCell align="right">{NOK(etterbetaling.brutto)}</Table.DataCell>
+    </Table.Row>
+    <Table.Row>
+      <Table.DataCell>Skatt</Table.DataCell>
+      <Table.DataCell align="right">{NOK(etterbetaling.skatt)}</Table.DataCell>
+    </Table.Row>
+    <Table.Row>
+      <Table.DataCell>Netto etterbetaling{suffix}</Table.DataCell>
+      <Table.DataCell align="right">{NOK(etterbetaling.netto)}</Table.DataCell>
+    </Table.Row>
+  </>
+)
 
 export const SimuleringGruppertPaaAar = ({ data }: { data: SimulertBeregning }) => {
   const aarMedPerioder = grupperPerioderPerAar(data)
@@ -25,10 +48,7 @@ export const SimuleringGruppertPaaAar = ({ data }: { data: SimulertBeregning }) 
                 </Table.Row>
               </Table.Header>
               <Table.Body>
-                <Table.Row>
-                  <Table.DataCell>Etterbetaling</Table.DataCell>
-                  <Table.DataCell align="right">{NOK(summerPerioder(aar.etterbetaling))}</Table.DataCell>
-                </Table.Row>
+                <EtterbetalingRader etterbetaling={summerEtterbetaling(aar.etterbetaling)} />
                 <Table.Row>
                   <Table.DataCell>Tilbakekreving</Table.DataCell>
                   <Table.DataCell align="right">{NOK(summerPerioder(aar.tilbakekreving))}</Table.DataCell>
@@ -51,6 +71,28 @@ export const SimuleringGruppertPaaAar = ({ data }: { data: SimulertBeregning }) 
           </Box>
         </Box>
       ))}
+      {aarMedPerioder.length > 1 && (
+        <Box maxWidth="70rem" background="neutral-soft" padding="space-20">
+          <Heading level="3" size="small">
+            Etterbetaling for hele perioden
+          </Heading>
+          <Box width="25rem" marginBlock="space-20">
+            <Table>
+              <Table.Header>
+                <Table.Row>
+                  <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+                  <Table.HeaderCell scope="col" align="right">
+                    Sum
+                  </Table.HeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                <EtterbetalingRader etterbetaling={summerEtterbetaling(data.etterbetaling)} suffix=" for perioden" />
+              </Table.Body>
+            </Table>
+          </Box>
+        </Box>
+      )}
     </>
   )
 }

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/UtbetalingTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/UtbetalingTable.tsx
@@ -9,11 +9,11 @@ export function summerPerioder(perioder: SimulertBeregningsperiode[]) {
 }
 
 export function summerEtterbetaling(perioder: SimulertBeregningsperiode[]) {
-  const skatt = perioder
-    .filter((periode) => periode.klasseType === 'SKAT')
+  const brutto = perioder
+    .filter((periode) => periode.klasseType === 'YTEL')
     .reduce((sum, periode) => sum + periode.beloep, 0)
   const netto = summerPerioder(perioder)
-  const brutto = netto - skatt
+  const skatt = netto - brutto
   return { brutto, skatt, netto }
 }
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/UtbetalingTable.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregne/UtbetalingTable.tsx
@@ -8,6 +8,15 @@ export function summerPerioder(perioder: SimulertBeregningsperiode[]) {
   return perioder.map((row) => row.beloep).reduce((sum, current) => sum + current, 0)
 }
 
+export function summerEtterbetaling(perioder: SimulertBeregningsperiode[]) {
+  const skatt = perioder
+    .filter((periode) => periode.klasseType === 'SKAT')
+    .reduce((sum, periode) => sum + periode.beloep, 0)
+  const netto = summerPerioder(perioder)
+  const brutto = netto - skatt
+  return { brutto, skatt, netto }
+}
+
 export const UtbetalingTable = ({ tittel, perioder }: { tittel: string; perioder: SimulertBeregningsperiode[] }) => {
   const sortertePerioder = [...perioder].sort((a, b) => compareDesc(new Date(a.fom), new Date(b.fom)))
 


### PR DESCRIPTION
# Simulering: brutto, skatt og netto etterbetaling

<img width="1120" height="394" alt="rewewre" src="https://github.com/user-attachments/assets/0536d7c1-ab03-49d2-b20a-757dc9b0de35" />

### Hvorfor er denne endringen nødvendig? ✨

Når omstillingsstønad eller barnepensjon innvilges tilbake i tid, viser simuleringen etterbetaling per år. Før viste den bare **netto** beløp, mens brutto og skatt lå gjemt inne i detalj accordionen.

Saksbehandler må oppgi **brutto** etterbetaling til f.eks. Statsforvalter og til bruker/verge, og måtte tidligere regne dette ut manuelt i et regneark.

Denne endringen viser oppsummert:

- Per år: Brutto etterbetaling, Skatt og Netto etterbetaling (Tilbakekreving beholdes som før).
- En totalsum for hele perioden når etterbetalingen strekker seg over flere år.

En viktig detalj: skatt kunne ikke plukkes ut på `klasseType`, fordi skattetrekk for barnepensjon (klassekode BPSKSKAT) ikke har samme klasseType som forskuddsskatt for omstillingsstønad (FSKTSKAT). Derfor utledes brutto fra ytelseslinjene (YTEL), og skatt regnes som resten (netto minus brutto). Da fanger vi all skatt uansett klasseType, og brutto pluss skatt blir alltid lik netto.

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-28472).

### Verdt å nevne

- Barnepensjon innvilget tilbake i tid: brutto, skatt og netto vises riktig per år, og brutto pluss skatt stemmer med netto (f.eks. brutto 6 510, skatt 1 104, netto 5 406).
- Omstillingsstønad med forskuddsskatt: skatt vises fortsatt riktig (uendret oppførsel).
- Sak over flere år: totalboksen "Etterbetaling for hele perioden" dukker opp og summerer korrekt.
- Sak med kun ett år: totalboksen vises ikke.
- Detalj accordionen er uendret og viser fortsatt alle enkeltlinjer.

