### PR TITLE
Resette avkorting ved rendering av Beregningsgrunnlag

### DIFF
--- a/apps/etterlatte-behandling/src/main/kotlin/behandling/VedtaksbrevService.kt
+++ b/apps/etterlatte-behandling/src/main/kotlin/behandling/VedtaksbrevService.kt
@@ -526,7 +526,6 @@ class VedtaksbrevService(
         coroutineScope {
             val trygdetidRequest = async { trygdetidKlient.hentTrygdetid(behandling.id, brukerTokenInfo) }
 
-            // TODO felles?
             val virkningsdato = (vedtak.innhold as VedtakInnholdDto.VedtakBehandlingDto).virkningstidspunkt.atDay(1)
 
             val avkorting = beregningKlient.hentBeregningOgAvkorting(behandling.id, brukerTokenInfo)

--- a/apps/etterlatte-behandling/src/test/kotlin/behandling/VedtaksbrevServiceTest.kt
+++ b/apps/etterlatte-behandling/src/test/kotlin/behandling/VedtaksbrevServiceTest.kt
@@ -2,8 +2,10 @@ package no.nav.etterlatte.behandling
 
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.confirmVerified
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
@@ -48,6 +50,7 @@ import no.nav.etterlatte.libs.testdata.behandling.VirkningstidspunktTestData
 import no.nav.etterlatte.libs.testdata.grunnlag.GrunnlagTestData
 import no.nav.etterlatte.sak.SakService
 import no.nav.etterlatte.vilkaarsvurdering.service.VilkaarsvurderingService
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.security.SecureRandom
@@ -94,6 +97,12 @@ internal class VedtaksbrevServiceTest {
         coEvery {
             brevKlient.opprettStrukturertBrev(any(), any(), any())
         } returns mockk()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        confirmVerified(brevKlient)
+        clearAllMocks()
     }
 
     @Test

--- a/apps/etterlatte-beregning/.run/etterlatte-beregning.dev-gcp.run.xml
+++ b/apps/etterlatte-beregning/.run/etterlatte-beregning.dev-gcp.run.xml
@@ -1,34 +1,35 @@
 <component name="ProjectRunConfigurationManager">
-    <configuration default="false" name="etterlatte-beregning.dev-gcp" type="JetRunConfigurationType">
-        <envs>
+  <configuration default="false" name="etterlatte-beregning.dev-gcp" type="JetRunConfigurationType">
+    <envs>
             <env name="HTTP_PORT" value="8089"/>
             <env name="LOGBACK_APPENDER" value="STDOUT"/>
-            <env name="DB_JDBC_URL" value="jdbc:postgresql://localhost:5433/postgres"/>
-            <env name="DB_PASSWORD" value="postgres"/>
-            <env name="DB_USERNAME" value="postgres"/>
-            <env name="ETTERLATTE_BEHANDLING_CLIENT_ID" value="59967ac8-009c-492e-a618-e5a0f6b3e4e4"/>
-            <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no"/>
-            <env name="ETTERLATTE_TRYGDETID_CLIENT_ID" value="8385435e-f3d7-45ec-be59-ebd1c71df735"/>
-            <env name="ETTERLATTE_TRYGDETID_URL" value="https://etterlatte-trygdetid.intern.dev.nav.no"/>
-            <env name="NAIS_APP_NAME" value="etterlatte-beregning"/>
-        </envs>
-        <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt"/>
-        <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-beregning.main"/>
-        <shortenClasspath name="NONE"/>
-        <extension name="net.ashald.envfile">
-            <option name="IS_ENABLED" value="true"/>
-            <option name="IS_SUBST" value="false"/>
-            <option name="IS_PATH_MACRO_SUPPORTED" value="false"/>
-            <option name="IS_IGNORE_MISSING_FILES" value="false"/>
-            <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false"/>
-            <ENTRIES>
-                <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false"/>
+      <env name="DB_JDBC_URL" value="jdbc:postgresql://localhost:5433/postgres" />
+      <env name="DB_PASSWORD" value="postgres" />
+      <env name="DB_USERNAME" value="postgres" />
+      <env name="ETTERLATTE_BEHANDLING_CLIENT_ID" value="59967ac8-009c-492e-a618-e5a0f6b3e4e4" />
+      <env name="ETTERLATTE_BEHANDLING_URL" value="https://etterlatte-behandling.intern.dev.nav.no" />
+      <env name="ETTERLATTE_TRYGDETID_CLIENT_ID" value="8385435e-f3d7-45ec-be59-ebd1c71df735" />
+      <env name="ETTERLATTE_TRYGDETID_URL" value="https://etterlatte-trygdetid.intern.dev.nav.no" />
+      <env name="NAIS_APP_NAME" value="etterlatte-beregning" />
+      <env name="ETTERLATTE_BEHANDLING_TRYGDETID_ENABLED" value="true" />
+    </envs>
+    <option name="MAIN_CLASS_NAME" value="no.nav.etterlatte.ApplicationKt" />
+    <module name="pensjon-etterlatte-saksbehandling.apps.etterlatte-beregning.main" />
+    <shortenClasspath name="NONE" />
+    <extension name="net.ashald.envfile">
+      <option name="IS_ENABLED" value="true" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" IS_EXECUTABLE="false" />
                 <ENTRY IS_ENABLED="true" PARSER="env" IS_EXECUTABLE="false"
                        PATH="apps/etterlatte-beregning/.env.dev-gcp"/>
-            </ENTRIES>
-        </extension>
-        <method v="2">
-            <option name="Make" enabled="true"/>
-        </method>
-    </configuration>
+      </ENTRIES>
+    </extension>
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
 </component>

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -565,6 +565,7 @@ data class Avkorting(
                     }
 
                 inntektsavkorting.copy(
+                    grunnlag = inntekt,
                     avkortingsperioder = avkortinger,
                     avkortetYtelseForventetInntekt =
                         avkortetYtelseForventetInntekt.map {
@@ -574,7 +575,7 @@ data class Avkorting(
             }
 
         val avkortetYtelse =
-            if (aarsoppgjoer.inntektsavkorting.size > 1) {
+            if (reberegnetInntektsavkorting.size > 1) {
                 beregnAvkortetYtelseMedRestanse(
                     aarsoppgjoer,
                     ytelseFoerAvkorting,
@@ -584,7 +585,7 @@ data class Avkorting(
                     brukNyeReglerAvkorting,
                 )
             } else {
-                reberegnetInntektsavkorting.first().let {
+                reberegnetInntektsavkorting.single().let {
                     val tomSluttenAvAaret =
                         tomSluttenAvAaretForAvkortetYtelse(aarsoppgjoer, ytelseFoerAvkorting, opphoerFom)
 

--- a/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
+++ b/apps/etterlatte-beregning/src/main/kotlin/avkorting/Avkorting.kt
@@ -565,7 +565,6 @@ data class Avkorting(
                     }
 
                 inntektsavkorting.copy(
-                    grunnlag = inntekt,
                     avkortingsperioder = avkortinger,
                     avkortetYtelseForventetInntekt =
                         avkortetYtelseForventetInntekt.map {
@@ -575,7 +574,7 @@ data class Avkorting(
             }
 
         val avkortetYtelse =
-            if (reberegnetInntektsavkorting.size > 1) {
+            if (aarsoppgjoer.inntektsavkorting.size > 1) {
                 beregnAvkortetYtelseMedRestanse(
                     aarsoppgjoer,
                     ytelseFoerAvkorting,
@@ -585,7 +584,7 @@ data class Avkorting(
                     brukNyeReglerAvkorting,
                 )
             } else {
-                reberegnetInntektsavkorting.single().let {
+                reberegnetInntektsavkorting.first().let {
                     val tomSluttenAvAaret =
                         tomSluttenAvAaretForAvkortetYtelse(aarsoppgjoer, ytelseFoerAvkorting, opphoerFom)
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/behandling/beregningsgrunnlag/BeregningsgrunnlagOmstillingsstoenad.tsx
@@ -10,6 +10,7 @@ import {
   oppdaterBehandlingsstatus,
   oppdaterBeregning,
   oppdaterBeregningsGrunnlag,
+  resetAvkorting,
 } from '~store/reducers/BehandlingReducer'
 import { IBehandlingStatus } from '~shared/types/IDetaljertBehandling'
 import React, { useContext, useEffect, useState } from 'react'
@@ -93,6 +94,7 @@ const BeregningsgrunnlagOmstillingsstoenad = () => {
   }
 
   useEffect(() => {
+    dispatch(resetAvkorting())
     hentBeregningsgrunnlagRequest(behandling.id, (result) => {
       if (result) {
         dispatch(oppdaterBeregningsGrunnlag(result))


### PR DESCRIPTION
Resetter avkorting i redux når man rendrer Beregningsgrunnlag, i tilfelle man gjør noe som trigger ny beregning og havner i status BEREGNET. Da vil avkorting bli gjort på nytt når man går til Beregning via "Neste side" eller sidemenyen.

Slik det er nå må man gjøre refresh for å se oppdatert avkorting og få satt status AVKORTET. Status forblir BEREGNET inntil man gjør det.