### PR TITLE
Bump the backend group with 41 updates - electric boogaloo

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,11 @@
 [plugins]
 versions = { id = "se.ascp.gradle.gradle-versions-filter", version = "0.1.16" }
-license = { id = 'com.github.jk1.dependency-license-report', version = '3.0.1' }
+license = { id = 'com.github.jk1.dependency-license-report', version = '3.1.2' }
 
 [versions]
-jackson-version = "2.20.1"
-jupiter-version = "6.0.1"
-ktor-version = "3.4.3"
+jackson-version = "2.21.3"
+jupiter-version = "6.1.0"
+ktor-version = "3.5.0"
 navfelles-token-version = "5.0.30"
 prometheus-version = "0.16.0"
 testcontainer-version = "1.21.4"
@@ -14,11 +14,11 @@ rapidsandrivers-version = "2026021921161771532161.7a37f8c9e0cc" # OBS! tbdlibs b
 tbdlibs-version = "2026.02.19-20.58-521cdd3c" # OBS! rapidsandrivers bruker denne. De bør stemme overens
 
 [libraries]
-cache-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.3" }
+cache-caffeine = { module = "com.github.ben-manes.caffeine:caffeine", version = "3.2.4" }
 
 database-hikaricp = { module = "com.zaxxer:HikariCP", version = "7.0.2" }
-database-flywaydb = { module = "org.flywaydb:flyway-core", version = "11.18.0" }
-database-flywaydbpostgres = { module = "org.flywaydb:flyway-database-postgresql", version = "11.18.0" }
+database-flywaydb = { module = "org.flywaydb:flyway-core", version = "12.6.2" }
+database-flywaydbpostgres = { module = "org.flywaydb:flyway-database-postgresql", version = "12.6.2" }
 database-postgresql = { module = "org.postgresql:postgresql", version = "42.7.11" }
 database-kotliquery = { module = "com.github.seratch:kotliquery", version = "1.9.1" }
 
@@ -32,7 +32,7 @@ kafka-avroserializer = { module = "io.confluent:kafka-avro-serializer", version 
 
 klage-kodeverk = { module = "no.nav.klage:klage-kodeverk", version = "3.3.8" }
 
-kotlin-result = { module = "com.michael-bull.kotlin-result:kotlin-result", version = "2.1.0" }
+kotlin-result = { module = "com.michael-bull.kotlin-result:kotlin-result", version = "2.3.1" }
 
 pdf-pdfbox = { module = "org.apache.pdfbox:pdfbox", version = "3.0.7" }
 
@@ -63,8 +63,8 @@ etterlatte-common = { module = "pensjon-etterlatte-felles:common", version = "20
 teamdokumenthandtering-avroschemas = { module = "no.nav.teamdokumenthandtering:teamdokumenthandtering-avro-schemas", version = "1.1.6" }
 brevbaker-api-model-common = { module = "no.nav.pensjon.brevbaker:brevbaker-api-model-common", version = "2.7.0"}
 
-logging-slf4japi = { module = "org.slf4j:slf4j-api", version = "2.0.17" }
-logging-logbackclassic = { module = "ch.qos.logback:logback-classic", version = "1.5.21" }
+logging-slf4japi = { module = "org.slf4j:slf4j-api", version = "2.0.18" }
+logging-logbackclassic = { module = "ch.qos.logback:logback-classic", version = "1.5.32" }
 logging-logstashlogbackencoder = { module = "net.logstash.logback:logstash-logback-encoder", version = "8.1" }
 
 metrics-micrometer-prometheus = { module = "io.micrometer:micrometer-registry-prometheus", version = "1.16.5" }
@@ -84,21 +84,21 @@ navfelles-tjenestespesifikasjoner-oppdragsimulering = { module = "com.github.nav
 navfelles-tjenestespesifikasjoner-tilbakekreving = { module = "com.github.navikt.pensjon-etterlatte-tjenestespesifikasjoner:tilbakekreving-v1-tjenestespesifikasjon", version.ref = "tjenestespesifikasjoner-version" }
 navfelles-tokenclientcore = { module = "no.nav.security:token-client-core", version.ref = "navfelles-token-version" }
 navfelles-tokenvalidationktor = { module = "no.nav.security:token-validation-ktor-v3", version.ref = "navfelles-token-version" }
-navfelles-mockoauth2server = { module = "no.nav.security:mock-oauth2-server", version = "3.0.3" }
+navfelles-mockoauth2server = { module = "no.nav.security:mock-oauth2-server", version = "4.0.0" }
 
 test-navfelles-rapidsandriversktor = { module = "com.github.navikt.tbd-libs:rapids-and-rivers-test", version.ref = "tbdlibs-version" }
 test-jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter-version" }
 test-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter-version" }
 test-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter-version" }
-test-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "6.0.3" }
-test-kotest-assertionscore = { module = "io.kotest:kotest-assertions-core", version = "6.0.7" }
-test-mockk = { module = "io.mockk:mockk", version = "1.14.6" }
+test-junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "6.1.0" }
+test-kotest-assertionscore = { module = "io.kotest:kotest-assertions-core", version = "6.1.11" }
+test-mockk = { module = "io.mockk:mockk", version = "1.14.9" }
 test-testcontainer-jupiter = { module = "org.testcontainers:junit-jupiter", version.ref = "testcontainer-version" }
 test-testcontainer-postgresql = { module = "org.testcontainers:postgresql", version.ref = "testcontainer-version" }
 test-testcontainer-kafka = { module = "org.testcontainers:kafka", version.ref = "testcontainer-version" }
 
 commons-compress = { module = "org.apache.commons:commons-compress", version = "1.28.0" }
-unleash-client = { module = "io.getunleash:unleash-client-java", version = "11.1.1" }
+unleash-client = { module = "io.getunleash:unleash-client-java", version = "12.2.2" }
 
 [bundles]
 jackson = ["jackson-datatypejsr310", "jackson-datatypejdk8", "jackson-modulekotlin"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,7 @@ license = { id = 'com.github.jk1.dependency-license-report', version = '3.1.2' }
 [versions]
 jackson-version = "2.21.3"
 jupiter-version = "6.1.0"
-ktor-version = "3.5.0"
+ktor-version = "3.5.1"
 navfelles-token-version = "5.0.30"
 prometheus-version = "0.16.0"
 testcontainer-version = "1.21.4"


### PR DESCRIPTION
Troubleshooting / fiksing av ktor-bumpen

Det var en regresjon i ktor 3.5.1, der kall som satte en egen timeout fikk problemer hvis det også var opentelemetry i pakkene. Har fått testet at et feilende kall fra behandling til brev i 3.5.0 fungerer i 3.5.1.