### PR TITLE
Før migrering av trygdetid må vi skru av auditlogging i databasen

### DIFF
--- a/apps/etterlatte-behandling/.nais/prod.yaml
+++ b/apps/etterlatte-behandling/.nais/prod.yaml
@@ -29,7 +29,7 @@ spec:
             envVarPrefix: DB
         flags:
           - name: cloudsql.enable_pgaudit
-            value: "true"
+            value: "false"
           - name: pgaudit.log
             value: 'write,ddl,role'
           - name: pgaudit.log_parameter


### PR DESCRIPTION
Skal skrus på igjen med en gang vi tar opp appen etter flytting av data