### PR TITLE
Setter base image til chainguard for backend-apper

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM gcr.io/distroless/java21
+FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
 ENV TZ="Europe/Oslo"
 WORKDIR /app
 COPY build/libs/*-*.jar ./
 COPY build/libs/*.jar ./
 EXPOSE 8080
 USER nonroot
-CMD ["app.jar"]
+CMD ["-jar", "app.jar"]


### PR DESCRIPTION
# Setter base image til chainguard for backend-apper

### Hvorfor er denne endringen nødvendig? ✨ 

Denne endringen burde sette etterlatte backend appene til å bruke chainguard image. Vi ønsker å sette opp `Digestabot` senere, der vi burde se på om vi klarer å gjøre dette for appene under Efterlatte domenet. 

Oppgaven og beskrivelse kan du finne på Favro → [her](https://favro.com/organization/98c34fb974ce445eac854de0/a64c6aad9b0d61ef6c0290bd?card=Nav-26362).

### Verdt å nevne

Har testet ved å:

* deploye `etterlatte-test` i dev og sjekket at workflowen peker på riktig image