### PR TITLE
Revert "Setter base image til chainguard for backend-apper"

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,8 +1,8 @@
-FROM europe-north1-docker.pkg.dev/cgr-nav/pull-through/nav.no/jre:openjdk-21
+FROM gcr.io/distroless/java21
 ENV TZ="Europe/Oslo"
 WORKDIR /app
 COPY build/libs/*-*.jar ./
 COPY build/libs/*.jar ./
 EXPOSE 8080
 USER nonroot
-CMD ["-jar", "app.jar"]
+CMD ["app.jar"]


### PR DESCRIPTION
Reverts navikt/pensjon-etterlatte-saksbehandling#8787 for å forsikre at deploy blir riktig.