### PR TITLE
Fikser manglende padding på Land-comboboxen.

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/index.css
+++ b/apps/etterlatte-saksbehandling-ui/client/src/index.css
@@ -35,11 +35,21 @@ li {
   padding: 0;
 }
 
+/* Gjenopprett padding for Aksel combobox-options som ellers nullstilles av regelen over (ul/li).*/
+.aksel-combobox__list-item,
+.aksel-combobox__list-item--loading,
+.aksel-combobox__list-item--no-options,
+.aksel-combobox__list-item--new-option,
+.aksel-combobox__list-item--max-selected {
+  padding: 12px;
+  margin: 2px 8px;
+}
+
 .breddepopover {
   min-width: 350px;
 }
 
 .padding-modal {
-    padding-top: 3rem !important;
-    padding-bottom: 1rem !important;
+  padding-top: 3rem !important;
+  padding-bottom: 1rem !important;
 }


### PR DESCRIPTION
Resetter padding og margin-regelen for combobox. Combobox bruker ul/li fremfor option, og blir derfor påvirket av regel vår om at ul/li har padding/margin 0.

Slik så det ut før:
<img width="351" height="443" alt="image" src="https://github.com/user-attachments/assets/2a9205ec-76da-49a7-8c30-712bc83a9d8b" />

Slik ser det ut nå:
<img width="306" height="432" alt="image" src="https://github.com/user-attachments/assets/e805c6b7-7bce-48da-a2ca-e37a7a1e1c90" />
