### PR TITLE
Omstillingsstønad varselbrev har ikke vedlegg, så jeg fjerner henting av redigerbart innhold for vedlegg på den typen brev

### DIFF
--- a/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
+++ b/apps/etterlatte-brev-api/src/main/kotlin/no/nav/etterlatte/brev/RedigerbartVedleggHenter.kt
@@ -86,15 +86,16 @@ class RedigerbartVedleggHenter(
     ) = when (sakType) {
         SakType.OMSTILLINGSSTOENAD -> {
             when (vedtakType) {
-                VedtakType.INNVILGELSE ->
+                VedtakType.INNVILGELSE -> {
                     listOf(
                         Pair(
                             Vedlegg.OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL,
                             BrevVedleggKey.OMS_BEREGNING,
                         ),
                     )
+                }
 
-                VedtakType.OPPHOER ->
+                VedtakType.OPPHOER -> {
                     if (harFeilutbetalingMedVarsel(bruker, behandlingId)) {
                         listOf(
                             Pair(
@@ -105,6 +106,7 @@ class RedigerbartVedleggHenter(
                     } else {
                         emptyList()
                     }
+                }
 
                 VedtakType.ENDRING -> {
                     if (brevtype == Brevtype.VARSEL && revurderingaarsak == Revurderingaarsak.AKTIVITETSPLIKT) {
@@ -137,31 +139,23 @@ class RedigerbartVedleggHenter(
                 }
 
                 else -> {
-                    if (brevtype == Brevtype.VARSEL) {
-                        listOf(
-                            Pair(
-                                Vedlegg.OMSTILLINGSSTOENAD_VEDLEGG_BEREGNING_UTFALL,
-                                BrevVedleggKey.OMS_BEREGNING,
-                            ),
-                        )
-                    } else {
-                        emptyList()
-                    }
+                    emptyList()
                 }
             }
         }
 
         SakType.BARNEPENSJON -> {
             when (vedtakType) {
-                VedtakType.INNVILGELSE ->
+                VedtakType.INNVILGELSE -> {
                     listOf(
                         Pair(
                             Vedlegg.BARNEPENSJON_VEDLEGG_BEREGNING_TRYGDETID_UTFALL,
                             BrevVedleggKey.BP_BEREGNING_TRYGDETID,
                         ),
                     )
+                }
 
-                VedtakType.OPPHOER ->
+                VedtakType.OPPHOER -> {
                     if (harFeilutbetalingMedVarsel(bruker, behandlingId)) {
                         listOf(
                             Pair(
@@ -172,8 +166,9 @@ class RedigerbartVedleggHenter(
                     } else {
                         emptyList()
                     }
+                }
 
-                VedtakType.ENDRING ->
+                VedtakType.ENDRING -> {
                     if (harFeilutbetalingMedVarsel(bruker, behandlingId)) {
                         listOf(
                             Pair(
@@ -193,6 +188,7 @@ class RedigerbartVedleggHenter(
                             ),
                         )
                     }
+                }
 
                 else -> {
                     if (brevtype == Brevtype.VARSEL) {


### PR DESCRIPTION
Det ble henta tidligere, men da gikk det fint fordi det ikke krevdes noe inndata til brev-templaten.