### PR TITLE
Bump github/codeql-action/init from 4.36.0 to 4.36.2

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # ratchet:github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # ratchet:github/codeql-action/init@v4
         with:
           languages: java
           queries: security-and-quality
@@ -80,7 +80,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # ratchet:github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # ratchet:github/codeql-action/init@v4
         with:
           languages: javascript
           queries: security-and-quality


### PR DESCRIPTION
Vi har feil i kodescanning pga mismatch mellom de to versjonene nå