### PR TITLE
Legg filter i URL

### DIFF
--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/MinOppgaveliste.tsx
@@ -27,13 +27,22 @@ import {
 } from '~components/oppgavebenk/utils/oppgaveSortering'
 import { SortKey } from '~components/oppgavebenk/oppgaverTable/OppgaverTable'
 import { VStack } from '@navikt/ds-react'
+import {
+  MIN_OPPGAVELISTE_URL_NOKLER,
+  useFilterMedUrl,
+} from '~components/oppgavebenk/filtreringAvOppgaver/useFilterMedUrl'
 
 interface Props {
   saksbehandlereIEnhet: Array<Saksbehandler>
 }
 
 export const MinOppgaveliste = ({ saksbehandlereIEnhet }: Props) => {
-  const [filter, setFilter] = useState<Filter>(hentMinOppgavelisteFilterFraLocalStorage())
+  const [filter, setFilter] = useFilterMedUrl(
+    MIN_OPPGAVELISTE_URL_NOKLER,
+    hentMinOppgavelisteFilterFraLocalStorage,
+    leggMinOppgavelisteFilterILocalsotrage
+  )
+
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(hentPagineringSizeFraLocalStorage())
   const [sortering, setSortering] = useState<OppgaveSortering>(hentSorteringFraLocalStorage())
@@ -79,10 +88,6 @@ export const MinOppgaveliste = ({ saksbehandlereIEnhet }: Props) => {
     setSortering(nyOppgaveSortering)
     leggTilSorteringILocalStorage(nyOppgaveSortering)
   }
-
-  useEffect(() => {
-    leggMinOppgavelisteFilterILocalsotrage(filter)
-  }, [filter])
 
   useEffect(() => {
     hentOppgaver()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavebenk.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavebenk.tsx
@@ -47,17 +47,16 @@ export const Oppgavebenk = () => {
     }
   }, [])
 
-  // Sett tab i URL ved mount hvis den mangler
+  // Sett tab i URL ved mount hvis den mangler.
+  // Vi leser window.location.search direkte fordi barnekomponenter (useFilterMedUrl) kan ha
+  // satt filter-params via history.replaceState før denne effekten kjører, men React Routers
+  // interne state (prev) er ikke oppdatert ennå og er stale. Leser vi window.location.search
+  // her bevares filter-params som barnet satte.
   useEffect(() => {
-    if (!searchParams.get('tab')) {
-      setSearchParams(
-        (prev) => {
-          const nyeParams = new URLSearchParams(prev)
-          nyeParams.set('tab', TAB_NUMMER[oppgavelisteValg])
-          return nyeParams
-        },
-        { replace: true }
-      )
+    const faktiskeParams = new URLSearchParams(window.location.search)
+    if (!faktiskeParams.get('tab')) {
+      faktiskeParams.set('tab', TAB_NUMMER[oppgavelisteValg])
+      setSearchParams(faktiskeParams, { replace: true })
     }
   }, [])
 

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavebenk.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavebenk.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode, useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router-dom'
 import { Tilgangsmelding } from '~components/oppgavebenk/components/Tilgangsmelding'
 import { useApiCall } from '~shared/hooks/useApiCall'
 import { saksbehandlereIEnhetApi } from '~shared/api/oppgaver'
@@ -6,7 +7,9 @@ import { Saksbehandler } from '~shared/types/saksbehandler'
 import {
   hentValgFraLocalStorage,
   leggValgILocalstorage,
+  NUMMER_TIL_TAB,
   OppgavelisteValg,
+  TAB_NUMMER,
 } from '~components/oppgavebenk/velgOppgaveliste/oppgavelisteValg'
 import { VelgOppgaveliste } from '~components/oppgavebenk/velgOppgaveliste/VelgOppgaveliste'
 import { GosysOppgaveliste } from '~components/oppgavebenk/GosysOppgaveliste'
@@ -25,9 +28,13 @@ export const Oppgavebenk = () => {
     return <Tilgangsmelding />
   }
 
-  const [oppgavelisteValg, setOppgavelisteValg] = useState<OppgavelisteValg>(
-    hentValgFraLocalStorage() as OppgavelisteValg
-  )
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const [oppgavelisteValg, setOppgavelisteValg] = useState<OppgavelisteValg>(() => {
+    const tabFraUrl = searchParams.get('tab')
+    if (tabFraUrl && NUMMER_TIL_TAB[tabFraUrl]) return NUMMER_TIL_TAB[tabFraUrl]
+    return hentValgFraLocalStorage() as OppgavelisteValg
+  })
 
   const [, hentSaksbehandlereIEnheterFetch] = useApiCall(saksbehandlereIEnhetApi)
   const [saksbehandlereIEnheter, setSaksbehandlereIEnheter] = useState<Array<Saksbehandler>>([])
@@ -40,9 +47,28 @@ export const Oppgavebenk = () => {
     }
   }, [])
 
+  // Sett tab i URL ved mount hvis den mangler
   useEffect(() => {
-    leggValgILocalstorage(oppgavelisteValg)
-  }, [oppgavelisteValg])
+    if (!searchParams.get('tab')) {
+      setSearchParams(
+        (prev) => {
+          const nyeParams = new URLSearchParams(prev)
+          nyeParams.set('tab', TAB_NUMMER[oppgavelisteValg])
+          return nyeParams
+        },
+        { replace: true }
+      )
+    }
+  }, [])
+
+  // Byttter tab: oppdaterer URL (fjerner filter-params), localStorage og state
+  const byttTab = (nyValg: OppgavelisteValg) => {
+    setOppgavelisteValg(nyValg)
+    leggValgILocalstorage(nyValg)
+    // Setter kun tab i URL – filtere fra forrige tab fjernes bevisst.
+    // Det nye tabets filter-params settes av useFilterMedUrl ved mount.
+    setSearchParams({ tab: TAB_NUMMER[nyValg] }, { replace: true })
+  }
 
   const rendreValgtOppgaveliste = (): ReactNode => {
     switch (oppgavelisteValg) {
@@ -58,7 +84,7 @@ export const Oppgavebenk = () => {
   return (
     <ProvideOppgavebenkContext>
       <Box padding="space-32">
-        <VelgOppgaveliste oppgavelisteValg={oppgavelisteValg} setOppgavelisteValg={setOppgavelisteValg} />
+        <VelgOppgaveliste oppgavelisteValg={oppgavelisteValg} setOppgavelisteValg={byttTab} />
         {rendreValgtOppgaveliste()}
       </Box>
     </ProvideOppgavebenkContext>

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/Oppgavelista.tsx
@@ -15,6 +15,7 @@ import {
   leggOppgavelistenFilterILocalStorage,
 } from '~components/oppgavebenk/filtreringAvOppgaver/filterLocalStorage'
 import { byggOppgaveSoekRequest } from '~components/oppgavebenk/filtreringAvOppgaver/filtrerOppgaver'
+import { OPPGAVELISTA_URL_NOKLER, useFilterMedUrl } from '~components/oppgavebenk/filtreringAvOppgaver/useFilterMedUrl'
 import { OppgavelisteValg } from '~components/oppgavebenk/velgOppgaveliste/oppgavelisteValg'
 import { Oppgaver } from '~components/oppgavebenk/oppgaver/Oppgaver'
 import { useOppgavebenkStateDispatcher } from '~components/oppgavebenk/state/OppgavebenkContext'
@@ -33,7 +34,12 @@ interface Props {
 }
 
 export const Oppgavelista = ({ saksbehandlereIEnhet }: Props) => {
-  const [filter, setFilter] = useState<Filter>(hentOppgavelistenFilterFraLocalStorage())
+  const [filter, setFilter] = useFilterMedUrl(
+    OPPGAVELISTA_URL_NOKLER,
+    hentOppgavelistenFilterFraLocalStorage,
+    (f: Filter) => leggOppgavelistenFilterILocalStorage({ ...f, sakEllerFnrFilter: '' })
+  )
+
   const [page, setPage] = useState<number>(1)
   const [rowsPerPage, setRowsPerPage] = useState<number>(hentPagineringSizeFraLocalStorage())
   const [sortering, setSortering] = useState<OppgaveSortering>(hentSorteringFraLocalStorage())
@@ -79,10 +85,6 @@ export const Oppgavelista = ({ saksbehandlereIEnhet }: Props) => {
     setSortering(nyOppgaveSortering)
     leggTilSorteringILocalStorage(nyOppgaveSortering)
   }
-
-  useEffect(() => {
-    leggOppgavelistenFilterILocalStorage({ ...filter, sakEllerFnrFilter: '' })
-  }, [filter])
 
   useEffect(() => {
     hentOppgaver()

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/useFilterMedUrl.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/filtreringAvOppgaver/useFilterMedUrl.ts
@@ -1,0 +1,127 @@
+import { useState, useEffect } from 'react'
+import { useSearchParams } from 'react-router-dom'
+import { Filter } from '~components/oppgavebenk/filtreringAvOppgaver/typer'
+
+/**
+ * Filter-felter som er tillatt i URL. SakEllerFnrFilter holdes utenfor av hensyn til personvern.
+ */
+export type FilterUrlNokler = 'frist' | 'saksbehandler' | 'enhet' | 'ytelse' | 'oppgavestatus' | 'oppgavetype'
+
+export const OPPGAVELISTA_URL_NOKLER: FilterUrlNokler[] = [
+  'frist',
+  'saksbehandler',
+  'enhet',
+  'ytelse',
+  'oppgavestatus',
+  'oppgavetype',
+]
+
+export const MIN_OPPGAVELISTE_URL_NOKLER: FilterUrlNokler[] = ['frist', 'ytelse', 'oppgavestatus', 'oppgavetype']
+
+function parseFilterFraUrl(
+  searchParams: URLSearchParams,
+  fallback: Filter,
+  urlNokkel: FilterUrlNokler[]
+): Filter | null {
+  const harNoenParams = urlNokkel.some((nokkel) => searchParams.has(nokkel))
+  if (!harNoenParams) return null
+
+  return {
+    ...fallback,
+    sakEllerFnrFilter: '', // aldri fra URL
+    ...(urlNokkel.includes('frist') && searchParams.has('frist')
+      ? { fristFilter: searchParams.get('frist') as Filter['fristFilter'] }
+      : {}),
+    ...(urlNokkel.includes('saksbehandler') && searchParams.has('saksbehandler')
+      ? { saksbehandlerFilter: searchParams.get('saksbehandler')! }
+      : {}),
+    ...(urlNokkel.includes('enhet') && searchParams.has('enhet')
+      ? { enhetsFilter: searchParams.get('enhet') as Filter['enhetsFilter'] }
+      : {}),
+    ...(urlNokkel.includes('ytelse') && searchParams.has('ytelse')
+      ? { ytelseFilter: searchParams.get('ytelse') as Filter['ytelseFilter'] }
+      : {}),
+    ...(urlNokkel.includes('oppgavestatus') && searchParams.has('oppgavestatus')
+      ? { oppgavestatusFilter: searchParams.get('oppgavestatus')!.split(',').filter(Boolean) }
+      : {}),
+    ...(urlNokkel.includes('oppgavetype') && searchParams.has('oppgavetype')
+      ? { oppgavetypeFilter: searchParams.get('oppgavetype')!.split(',').filter(Boolean) }
+      : {}),
+  }
+}
+
+/**
+ * Bygger nye search params basert på faktisk nåværende URL (window.location.search).
+ * Bevarer tab-parameteren og erstatter kun filter-parameterne for dette tabets nøkler.
+ *
+ * Vi bruker window.location.search fremfor React Routers searchParams-kontekst fordi
+ * konteksten kan ligge ett render bak (stale) ved tab-bytte, noe som vil gi feil URL.
+ */
+function byggSearchParams(filter: Filter, urlNokkel: FilterUrlNokler[]): URLSearchParams {
+  const params = new URLSearchParams(window.location.search)
+
+  // Fjern alle eksisterende filter-params for dette tabets nøkler
+  urlNokkel.forEach((nokkel) => params.delete(nokkel))
+
+  // Sett nye filter-params
+  if (urlNokkel.includes('frist')) params.set('frist', filter.fristFilter)
+  if (urlNokkel.includes('saksbehandler')) params.set('saksbehandler', filter.saksbehandlerFilter)
+  if (urlNokkel.includes('enhet')) params.set('enhet', filter.enhetsFilter)
+  if (urlNokkel.includes('ytelse')) params.set('ytelse', filter.ytelseFilter)
+  if (urlNokkel.includes('oppgavestatus')) params.set('oppgavestatus', filter.oppgavestatusFilter.join(','))
+  if (urlNokkel.includes('oppgavetype')) params.set('oppgavetype', filter.oppgavetypeFilter.join(','))
+
+  return params
+}
+
+/**
+ * Hook som synkroniserer filter med URL og localStorage.
+ *
+ * Prioritetsrekkefølge ved initialisering:
+ * 1. URL-parametere (overskrives av bruker ved navigasjon til en delt lenke)
+ * 2. localStorage (husker forrige valg)
+ *
+ * Når brukeren endrer et filter oppdateres URL og localStorage uten sidereload.
+ * Ingen loop: URL leses kun én gang ved mount, ikke i en reaktiv effect.
+ *
+ * Vi leser/skriver window.location.search direkte overalt fordi React Routers
+ * searchParams-kontekst kan ligge ett render bak ved tab-bytte.
+ */
+export function useFilterMedUrl(
+  urlNokler: FilterUrlNokler[],
+  hentFraLocalStorage: () => Filter,
+  lagreILocalStorage: (filter: Filter) => void
+): [Filter, (filter: Filter) => void] {
+  const [, setSearchParams] = useSearchParams()
+
+  const [filter, setFilterState] = useState<Filter>(() => {
+    const faktiskeParams = new URLSearchParams(window.location.search)
+    const fraLocalStorage = hentFraLocalStorage()
+    const fraUrl = parseFilterFraUrl(faktiskeParams, fraLocalStorage, urlNokler)
+
+    if (fraUrl !== null) {
+      lagreILocalStorage(fraUrl)
+      return fraUrl
+    }
+
+    return fraLocalStorage
+  })
+
+  // Ved mount: hvis URL ikke har filter-parametere, sett dem fra gjeldende filter.
+  // Kjøres kun én gang. Ingen loop siden vi ikke lytter på URL-endringer.
+  useEffect(() => {
+    const faktiskeParams = new URLSearchParams(window.location.search)
+    const harNoenParams = urlNokler.some((nokkel) => faktiskeParams.has(nokkel))
+    if (!harNoenParams) {
+      setSearchParams(byggSearchParams(filter, urlNokler), { replace: true })
+    }
+  }, [])
+
+  const setFilter = (nyFilter: Filter) => {
+    setFilterState(nyFilter)
+    lagreILocalStorage(nyFilter)
+    setSearchParams(byggSearchParams(nyFilter, urlNokler), { replace: true })
+  }
+
+  return [filter, setFilter]
+}

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/velgOppgaveliste/VelgOppgaveliste.tsx
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/velgOppgaveliste/VelgOppgaveliste.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, ReactNode, SetStateAction, useEffect } from 'react'
+import React, { ReactNode, useEffect } from 'react'
 import styled from 'styled-components'
 import { Loader, Tabs } from '@navikt/ds-react'
 import { InboxIcon, PersonIcon } from '@navikt/aksel-icons'
@@ -10,7 +10,7 @@ import { mapResult } from '~shared/api/apiUtils'
 
 interface Props {
   oppgavelisteValg: OppgavelisteValg
-  setOppgavelisteValg: Dispatch<SetStateAction<OppgavelisteValg>>
+  setOppgavelisteValg: (valg: OppgavelisteValg) => void
 }
 
 export const VelgOppgaveliste = ({ oppgavelisteValg, setOppgavelisteValg }: Props): ReactNode => {

--- a/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/velgOppgaveliste/oppgavelisteValg.ts
+++ b/apps/etterlatte-saksbehandling-ui/client/src/components/oppgavebenk/velgOppgaveliste/oppgavelisteValg.ts
@@ -6,15 +6,27 @@ export enum OppgavelisteValg {
   GOSYS_OPPGAVER = 'GosysOpggaver',
 }
 
-const OPPGAVELISTE_VALG_KEY = 'oppgaveliste'
+export const TAB_NUMMER: Record<OppgavelisteValg, string> = {
+  [OppgavelisteValg.OPPGAVELISTA]: '1',
+  [OppgavelisteValg.MIN_OPPGAVELISTE]: '2',
+  [OppgavelisteValg.GOSYS_OPPGAVER]: '3',
+}
+
+export const NUMMER_TIL_TAB: Record<string, OppgavelisteValg> = {
+  '1': OppgavelisteValg.OPPGAVELISTA,
+  '2': OppgavelisteValg.MIN_OPPGAVELISTE,
+  '3': OppgavelisteValg.GOSYS_OPPGAVER,
+}
+
+const OPPGAVELISTE_VALG = 'oppgaveliste'
 
 const initialValg = OppgavelisteValg.OPPGAVELISTA
 
-export const leggValgILocalstorage = (valg: string) => localStorage.setItem(OPPGAVELISTE_VALG_KEY, valg)
+export const leggValgILocalstorage = (valg: string) => localStorage.setItem(OPPGAVELISTE_VALG, valg)
 
 export const hentValgFraLocalStorage = (): string => {
   try {
-    const valg = localStorage[OPPGAVELISTE_VALG_KEY]
+    const valg = localStorage[OPPGAVELISTE_VALG]
     if (!!valg) return valg
     else return initialValg
   } catch {


### PR DESCRIPTION
Når man endrer filter i oppgavelisten skal filteret legges i URL i tillegg til å huskes av localstorage (som før).
Hvis man går til Gjenny via en URL som inneholder filter i URL skal filteret settes slik som i URL.
Oppgavelisten, Min oppgaveliste og Gosys-oppgaver er nå ulike tabs i URL slik at filter ikke blir med på tvers av tabs men holdes separat.